### PR TITLE
개인 대시보드 확인 api 연결 & 사이드 페이지 api 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-datepicker": "^7.3.0",
     "react-dom": "^18.3.1",
     "react-icons": "^5.2.1",
+    "react-intersection-observer": "^9.13.0",
     "react-modal": "^3.16.1",
     "react-paginate": "^8.2.0",
     "react-router-dom": "^6.25.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import {
   RouterProvider,
   createRoutesFromElements,
   Route,
+  Navigate,
 } from 'react-router-dom';
 import MainPage from './pages/MainPage';
 import LoginPage from './pages/LoginPage';
@@ -25,8 +26,9 @@ const queryClient = new QueryClient();
 const router = createBrowserRouter(
   createRoutesFromElements(
     <>
-      <Route path="/" element={<MainPage />}>
-        <Route path="personalBlock/:id" element={<SidePage />} />
+      <Route path="/" element={<Navigate to="/1" replace />} />
+      <Route path="/:id" element={<MainPage />}>
+        <Route path="/:id/personalBlock/:blockId" element={<SidePage />} />
       </Route>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/api/oauth2/callback/:provider" element={<OAuthRedirectHandler />} />

--- a/src/api/BoardApi.tsx
+++ b/src/api/BoardApi.tsx
@@ -4,10 +4,14 @@ import { TeamDashboardResponse } from '../types/TeamDashBoard';
 import { StatusPersonalBlock } from '../types/PersonalBlock';
 
 export const getDashBoard = async (
-  id: number | string
+  id: number | string,
+  page: number = 0, // default 페이지 0으로 설정
+  size: number = 10
 ): Promise<StatusPersonalBlock | undefined> => {
   try {
-    const response = await axiosInstance.get(`/blocks?dashboardId=${id}&progress=NOT_STARTED`);
+    const response = await axiosInstance.get(
+      `/blocks?dashboardId=${id}&progress=NOT_STARTED&page=${page}&size=${size}`
+    );
     // console.log(response.data.data);
     return response.data.data as StatusPersonalBlock;
   } catch (error) {

--- a/src/api/BoardApi.tsx
+++ b/src/api/BoardApi.tsx
@@ -1,6 +1,19 @@
 import { axiosInstance } from '../utils/apiConfig';
 import { PersonalDashBoard, PersonalSearchDashBoard } from '../types/PersonalDashBoard';
 import { TeamDashboardResponse } from '../types/TeamDashBoard';
+import { StatusPersonalBlock } from '../types/PersonalBlock';
+
+export const getDashBoard = async (
+  id: number | string
+): Promise<StatusPersonalBlock | undefined> => {
+  try {
+    const response = await axiosInstance.get(`/blocks?dashboardId=${id}&progress=NOT_STARTED`);
+    // console.log(response.data.data);
+    return response.data.data as StatusPersonalBlock;
+  } catch (error) {
+    console.error('Error fetching data:', error);
+  }
+};
 
 export const createDashBoard = async (data: PersonalDashBoard): Promise<void> => {
   try {

--- a/src/api/PersonalBlockApi.ts
+++ b/src/api/PersonalBlockApi.ts
@@ -1,8 +1,8 @@
-import { PersonalBlock } from '../types/PersonalBlock';
+import { BlockListResDto } from '../types/PersonalBlock';
 import { axiosInstance } from '../utils/apiConfig';
 
 // 블록 생성 post
-export const createPersonalBlock = async (data: PersonalBlock): Promise<number | null> => {
+export const createPersonalBlock = async (data: BlockListResDto): Promise<number | null> => {
   try {
     const response = await axiosInstance.post('/blocks/', data);
     console.log(response.data);
@@ -19,15 +19,30 @@ export const createPersonalBlock = async (data: PersonalBlock): Promise<number |
 /*
 ! /blocks/뒤에 대시보드 id 들어가야 함 (지금은 임시로 1로 되어 있음)
 */
-export const patchPersonalBlock = async (data: PersonalBlock): Promise<number | null> => {
+export const patchPersonalBlock = async (
+  blockId: string | undefined,
+  data: BlockListResDto
+): Promise<number | null> => {
   try {
-    const response = await axiosInstance.patch('/blocks/1', data);
+    const response = await axiosInstance.patch(`/blocks/${blockId}`, data);
     console.log(response.data);
 
     return response.data.data.blockId;
   } catch (error) {
     console.error('Error fetching data:', error);
 
+    return null;
+  }
+};
+
+// 블록 확인 api
+export const getPersonalBlock = async (blockId: string | null): Promise<BlockListResDto | null> => {
+  try {
+    const response = await axiosInstance.get(`/blocks/${blockId}`);
+    // console.log(response.data.data);
+    return response.data.data;
+  } catch (error) {
+    console.error('Error fetching data:', error);
     return null;
   }
 };

--- a/src/components/Block.tsx
+++ b/src/components/Block.tsx
@@ -4,42 +4,68 @@ import deleteicon from '../img/delete.png';
 import profile from '../img/kakaoprofileimage.png';
 import * as S from '../styles/DashboardStyled';
 import { Draggable } from 'react-beautiful-dnd';
+import { BlockListResDto } from '../types/PersonalBlock';
+import { Link, useBlocker } from 'react-router-dom';
+import { getPersonalBlock } from '../api/PersonalBlockApi';
+import { useEffect, useState } from 'react';
 
 type Props = {
-  text: string;
+  blockId: string;
+  title: string;
   index: number;
+  contents: string;
+  dDay: number;
+  dashboardId: string;
 };
-const Block = ({ text, index }: Props) => {
+
+const Block = ({ title, index, blockId, contents, dDay, dashboardId }: Props) => {
+  const updatedBlockId = blockId ? (parseInt(blockId, 10) + 1).toString() : '1';
+
+  // useEffect(() => {
+  //   const fetchData = async () => {
+  //     if (blockId) {
+  //       // blockId가 null이 아닌 경우에만 호출
+  //       const data = await getPersonalBlock(blockId);
+  //       console.log(data);
+  //       setBlock(data);
+  //     }
+  //   };
+
+  //   fetchData();
+  // }, [blockId]);
+
   return (
-    <Draggable draggableId={text} key={text} index={index}>
-      {provided => (
-        <S.BlockContainer
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-        >
-          <Flex gap="6px" justifyContent="flex-end">
-            <S.ImageIconWrapper>
-              <img src={edit} alt="편집 버튼" />
-            </S.ImageIconWrapper>
-            <S.ImageIconWrapper>
-              <img src={deleteicon} alt="편집 버튼" />
-            </S.ImageIconWrapper>
-          </Flex>
-          <Flex justifyContent="space-between" margin="0 0 8px 0">
-            <h3>{text}</h3>
-            <span>D-10</span>
-          </Flex>
-          {/* <p>집에서 빨래 바구니의 옷을 가지고 세탁실에...</p> */}
-          <Flex>
-            <S.ProfileImageWrapper>
+    <Link to={`personalBlock/${blockId}`}>
+      <Draggable draggableId={updatedBlockId} key={updatedBlockId} index={index}>
+        {provided => (
+          <S.BlockContainer
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+          >
+            <Flex gap="6px" justifyContent="flex-end">
+              <S.ImageIconWrapper>
+                <img src={edit} alt="편집 버튼" />
+              </S.ImageIconWrapper>
+              <S.ImageIconWrapper>
+                <img src={deleteicon} alt="편집 버튼" />
+              </S.ImageIconWrapper>
+            </Flex>
+            <Flex justifyContent="space-between" margin="0 0 8px 0">
+              <h3>{title}</h3>
+              <span>D-{dDay}</span>
+            </Flex>
+            <p>{contents}</p>
+            <Flex>
+              {/* <S.ProfileImageWrapper>
               <img src={profile} />
             </S.ProfileImageWrapper>
-            <span>명디우</span>
-          </Flex>
-        </S.BlockContainer>
-      )}
-    </Draggable>
+            <span>{blockId}</span> */}
+            </Flex>
+          </S.BlockContainer>
+        )}
+      </Draggable>
+    </Link>
   );
 };
 export default Block;

--- a/src/components/CompletedDashboard.tsx
+++ b/src/components/CompletedDashboard.tsx
@@ -2,62 +2,83 @@ import { useNavigate, Outlet } from 'react-router-dom';
 import Block from './Block';
 import * as S from '../styles/DashboardStyled';
 import { createPersonalBlock } from '../api/PersonalBlockApi';
+import { useAtom } from 'jotai';
+import { visibleAtom } from '../contexts/sideScreenAtom';
+import SidePage from '../pages/SidePage';
 import { Droppable } from 'react-beautiful-dnd';
+import theme from '../styles/Theme/Theme';
+import main2 from '../img/main2.png';
+import { BlockListResDto, StatusPersonalBlock } from '../types/PersonalBlock';
 
 type Props = {
-  backGroundColor?: string;
-  highlightColor?: string;
-  progress?: string;
-  imgSrc?: string;
-  list: string[];
+  // list: StatusPersonalBlock | undefined;
+  list: BlockListResDto[];
   id: string;
+  dashboardId: string;
 };
 
-const CompletedDashboard = ({
-  backGroundColor,
-  highlightColor,
-  progress,
-  imgSrc,
-  id,
-  list,
-}: Props) => {
+const CompletedDashboard = ({ list, id, dashboardId }: Props) => {
   const navigate = useNavigate();
+  // const blocks = list.flatMap((item: StatusPersonalBlock) => item.blockListResDto);
+  // const blocks = list?.blockListResDto;
+
+  const settings = {
+    backGroundColor: '#F7F1FF',
+    highlightColor: theme.color.main2,
+    progress: '완료',
+    imgSrc: main2,
+  };
 
   // + 버튼 누르면 사이드 페이지로 이동
   const handleAddBtn = async () => {
     // 초기 post 요청은 빈 내용으로 요청. 추후 patch로 자동 저장.
     const now = new Date();
+    const startDate = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')} 00:00`;
     const deadLine = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')} 23:59`;
 
     const data = {
-      dashboardId: 1,
+      dashboardId: dashboardId,
       title: '',
       contents: '',
-      progress: 'COMPLETED',
+      progress: 'NOT_STARTED',
+      startDate: startDate,
       deadLine: deadLine,
     };
 
     const blockId = await createPersonalBlock(data);
     // console.log(blockId);
 
+    const { highlightColor, progress } = settings;
     navigate(`/personalBlock/${blockId}`, { state: { highlightColor, progress } });
   };
 
   return (
-    <S.CardContainer backGroundColor={backGroundColor}>
+    <S.CardContainer backGroundColor={settings.backGroundColor}>
       <header>
-        <S.StatusBarContainer highlightColor={highlightColor}>
-          <span>{progress}</span>
+        <S.StatusBarContainer highlightColor={settings.highlightColor}>
+          <span>{settings.progress}</span>
         </S.StatusBarContainer>
         <S.AddButtonWrapper onClick={handleAddBtn}>
-          <img src={imgSrc} alt="블록 더하는 버튼" />
+          <img src={settings.imgSrc} alt="블록 더하는 버튼" />
         </S.AddButtonWrapper>
       </header>
       <Droppable droppableId={id}>
         {provided => (
-          <S.BoxContainer ref={provided.innerRef} className={id} {...provided.droppableProps}>
-            {list.map((text, index) => (
-              <Block key={text} index={index} text={text} />
+          <S.BoxContainer
+            ref={provided.innerRef}
+            className="container"
+            {...provided.droppableProps}
+          >
+            {list?.map((block, index) => (
+              <Block
+                dashboardId={dashboardId}
+                key={block.blockId}
+                index={index}
+                title={block.title ?? ''}
+                dDay={block.dDay ?? 0}
+                contents={block.contents ?? ''}
+                blockId={block.blockId ?? '0'}
+              />
             ))}
             {provided.placeholder}
           </S.BoxContainer>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,3 +1,5 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+import { getDashBoard } from '../api/BoardApi';
 import * as S from '../styles/DashboardStyled';
 import { DashboardItem } from '../types/PersonalDashBoard';
 import { TeamDashboardInfoResDto } from '../types/TeamDashBoard';
@@ -7,11 +9,26 @@ interface Props {
   dashboard?: DashboardItem[] | TeamDashboardInfoResDto[];
 }
 const Dashboard = ({ text, dashboard }: Props) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const id = location.pathname.split('/')[1];
+
+  const onClick = (id: number | string) => {
+    navigate(`/${id}`);
+  };
+
   return (
     <S.DashboardContainer>
       <h6>{text} 대시보드</h6>
       {dashboard?.map((value, index) => (
-        <S.DashboardItem key={index}>{value.title}</S.DashboardItem>
+        <S.DashboardItem
+          key={index}
+          onClick={() => {
+            onClick(value.dashboardId ?? 0);
+          }}
+        >
+          {value.title}
+        </S.DashboardItem>
       ))}
     </S.DashboardContainer>
   );

--- a/src/components/InProgressDashboard.tsx
+++ b/src/components/InProgressDashboard.tsx
@@ -6,61 +6,79 @@ import { useAtom } from 'jotai';
 import { visibleAtom } from '../contexts/sideScreenAtom';
 import SidePage from '../pages/SidePage';
 import { Droppable } from 'react-beautiful-dnd';
+import theme from '../styles/Theme/Theme';
+import main from '../img/main.png';
+import { BlockListResDto, StatusPersonalBlock } from '../types/PersonalBlock';
 
 type Props = {
-  backGroundColor?: string;
-  highlightColor?: string;
-  progress?: string;
-  imgSrc?: string;
-  list: string[];
+  // list: StatusPersonalBlock | undefined;
+  list: BlockListResDto[];
   id: string;
+  dashboardId: string;
 };
 
-const InProgressDashboard = ({
-  backGroundColor,
-  highlightColor,
-  progress,
-  imgSrc,
-  id,
-  list,
-}: Props) => {
+const InProgressDashboard = ({ list, id, dashboardId }: Props) => {
   const navigate = useNavigate();
+  // const blocks = list.flatMap((item: StatusPersonalBlock) => item.blockListResDto);
+  // const blocks = list?.blockListResDto;
+
+  const settings = {
+    backGroundColor: '#EDF3FF',
+    highlightColor: theme.color.main,
+    progress: '진행 중',
+    imgSrc: main,
+  };
 
   // + 버튼 누르면 사이드 페이지로 이동
   const handleAddBtn = async () => {
     // 초기 post 요청은 빈 내용으로 요청. 추후 patch로 자동 저장.
     const now = new Date();
+    const startDate = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')} 00:00`;
     const deadLine = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')} 23:59`;
 
     const data = {
-      dashboardId: 1,
+      dashboardId: dashboardId,
       title: '',
       contents: '',
-      progress: 'IN_PROGRESS',
+      progress: 'NOT_STARTED',
+      startDate: startDate,
       deadLine: deadLine,
     };
 
     const blockId = await createPersonalBlock(data);
     // console.log(blockId);
 
+    const { highlightColor, progress } = settings;
     navigate(`/personalBlock/${blockId}`, { state: { highlightColor, progress } });
   };
 
   return (
-    <S.CardContainer backGroundColor={backGroundColor}>
+    <S.CardContainer backGroundColor={settings.backGroundColor}>
       <header>
-        <S.StatusBarContainer highlightColor={highlightColor}>
-          <span>{progress}</span>
+        <S.StatusBarContainer highlightColor={settings.highlightColor}>
+          <span>{settings.progress}</span>
         </S.StatusBarContainer>
         <S.AddButtonWrapper onClick={handleAddBtn}>
-          <img src={imgSrc} alt="블록 더하는 버튼" />
+          <img src={settings.imgSrc} alt="블록 더하는 버튼" />
         </S.AddButtonWrapper>
       </header>
       <Droppable droppableId={id}>
         {provided => (
-          <S.BoxContainer ref={provided.innerRef} className={id} {...provided.droppableProps}>
-            {list.map((text, index) => (
-              <Block key={text} index={index} text={text} />
+          <S.BoxContainer
+            ref={provided.innerRef}
+            className="container"
+            {...provided.droppableProps}
+          >
+            {list?.map((block, index) => (
+              <Block
+                dashboardId={dashboardId}
+                key={block.blockId}
+                index={index}
+                title={block.title ?? ''}
+                dDay={block.dDay ?? 0}
+                contents={block.contents ?? ''}
+                blockId={block.blockId ?? '0'}
+              />
             ))}
             {provided.placeholder}
           </S.BoxContainer>

--- a/src/components/NotStartedDashboard.tsx
+++ b/src/components/NotStartedDashboard.tsx
@@ -9,15 +9,18 @@ import { Droppable } from 'react-beautiful-dnd';
 import theme from '../styles/Theme/Theme';
 import main3 from '../img/main3.png';
 import { BlockListResDto, StatusPersonalBlock } from '../types/PersonalBlock';
+import { useInView } from 'react-intersection-observer';
+import { useEffect } from 'react';
 
 type Props = {
   // list: StatusPersonalBlock | undefined;
   list: BlockListResDto[];
   id: string;
   dashboardId: string;
+  onLoadMore: () => void;
 };
 
-const NotStartedDashboard = ({ list, id, dashboardId }: Props) => {
+const NotStartedDashboard = ({ list, id, dashboardId, onLoadMore }: Props) => {
   const navigate = useNavigate();
   // const blocks = list.flatMap((item: StatusPersonalBlock) => item.blockListResDto);
   // const blocks = list?.blockListResDto;
@@ -54,6 +57,17 @@ const NotStartedDashboard = ({ list, id, dashboardId }: Props) => {
     });
   };
 
+  // 세로 무한 스크롤
+  const { ref: lastBlockRef, inView } = useInView({
+    threshold: 0, // 마지막 블록이 0% 보였을 때를 감지
+  });
+
+  useEffect(() => {
+    if (inView) {
+      onLoadMore(); // 부모 컴포넌트에 새로운 데이터 요청
+    }
+  }, [inView]);
+
   return (
     <S.CardContainer backGroundColor={settings.backGroundColor}>
       <header>
@@ -71,7 +85,7 @@ const NotStartedDashboard = ({ list, id, dashboardId }: Props) => {
             className="container"
             {...provided.droppableProps}
           >
-            {list?.map((block, index) => (
+            {/* {list?.map((block, index) => (
               <Block
                 dashboardId={dashboardId}
                 key={block.blockId}
@@ -81,7 +95,22 @@ const NotStartedDashboard = ({ list, id, dashboardId }: Props) => {
                 contents={block.contents ?? ''}
                 blockId={block.blockId ?? '0'}
               />
-            ))}
+            ))} */}
+            {list?.map((block, index) => {
+              const isLastBlock = index === list.length - 1;
+              return (
+                <div key={block.blockId} ref={isLastBlock ? lastBlockRef : null}>
+                  <Block
+                    dashboardId={dashboardId}
+                    index={index}
+                    title={block.title ?? ''}
+                    dDay={block.dDay ?? 0}
+                    contents={block.contents ?? ''}
+                    blockId={block.blockId ?? '0'}
+                  />
+                </div>
+              );
+            })}
             {provided.placeholder}
           </S.BoxContainer>
         )}

--- a/src/components/NotStartedDashboard.tsx
+++ b/src/components/NotStartedDashboard.tsx
@@ -10,7 +10,7 @@ import theme from '../styles/Theme/Theme';
 import main3 from '../img/main3.png';
 import { BlockListResDto, StatusPersonalBlock } from '../types/PersonalBlock';
 import { useInView } from 'react-intersection-observer';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 type Props = {
   // list: StatusPersonalBlock | undefined;
@@ -22,9 +22,6 @@ type Props = {
 
 const NotStartedDashboard = ({ list, id, dashboardId, onLoadMore }: Props) => {
   const navigate = useNavigate();
-  // const blocks = list.flatMap((item: StatusPersonalBlock) => item.blockListResDto);
-  // const blocks = list?.blockListResDto;
-
   const settings = {
     backGroundColor: '#E8FBFF',
     highlightColor: theme.color.main3,
@@ -67,6 +64,8 @@ const NotStartedDashboard = ({ list, id, dashboardId, onLoadMore }: Props) => {
       onLoadMore(); // 부모 컴포넌트에 새로운 데이터 요청
     }
   }, [inView]);
+
+  // todo: 다시 렌더링 됐을 때 이전 스크롤 위치를 기억했다가 그대로 보여줘야함
 
   return (
     <S.CardContainer backGroundColor={settings.backGroundColor}>

--- a/src/components/NotStartedDashboard.tsx
+++ b/src/components/NotStartedDashboard.tsx
@@ -8,14 +8,19 @@ import SidePage from '../pages/SidePage';
 import { Droppable } from 'react-beautiful-dnd';
 import theme from '../styles/Theme/Theme';
 import main3 from '../img/main3.png';
+import { BlockListResDto, StatusPersonalBlock } from '../types/PersonalBlock';
 
 type Props = {
-  list: string[];
+  // list: StatusPersonalBlock | undefined;
+  list: BlockListResDto[];
   id: string;
+  dashboardId: string;
 };
 
-const NotStartedDashboard = ({ list, id }: Props) => {
+const NotStartedDashboard = ({ list, id, dashboardId }: Props) => {
   const navigate = useNavigate();
+  // const blocks = list.flatMap((item: StatusPersonalBlock) => item.blockListResDto);
+  // const blocks = list?.blockListResDto;
 
   const settings = {
     backGroundColor: '#E8FBFF',
@@ -28,13 +33,15 @@ const NotStartedDashboard = ({ list, id }: Props) => {
   const handleAddBtn = async () => {
     // 초기 post 요청은 빈 내용으로 요청. 추후 patch로 자동 저장.
     const now = new Date();
+    const startDate = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')} 00:00`;
     const deadLine = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')} 23:59`;
 
     const data = {
-      dashboardId: 1,
+      dashboardId: dashboardId,
       title: '',
       contents: '',
       progress: 'NOT_STARTED',
+      startDate: startDate,
       deadLine: deadLine,
     };
 
@@ -42,7 +49,9 @@ const NotStartedDashboard = ({ list, id }: Props) => {
     // console.log(blockId);
 
     const { highlightColor, progress } = settings;
-    navigate(`/personalBlock/${blockId}`, { state: { highlightColor, progress } });
+    navigate(`personalBlock/${blockId}`, {
+      state: { highlightColor, progress, blockId },
+    });
   };
 
   return (
@@ -62,8 +71,16 @@ const NotStartedDashboard = ({ list, id }: Props) => {
             className="container"
             {...provided.droppableProps}
           >
-            {list.map((text, index) => (
-              <Block key={text} index={index} text={text} />
+            {list?.map((block, index) => (
+              <Block
+                dashboardId={dashboardId}
+                key={block.blockId}
+                index={index}
+                title={block.title ?? ''}
+                dDay={block.dDay ?? 0}
+                contents={block.contents ?? ''}
+                blockId={block.blockId ?? '0'}
+              />
             ))}
             {provided.placeholder}
           </S.BoxContainer>

--- a/src/contexts/OAuthRedirectHandler.tsx
+++ b/src/contexts/OAuthRedirectHandler.tsx
@@ -29,7 +29,7 @@ const OAuthRedirectHandler = () => {
   useEffect(() => {
     if (loginToken.accessToken) {
       login(loginToken);
-      navigate('/');
+      navigate('/1'); // 기본 대시보드 불러올 라우터로 설정
     }
   }, [loginToken, login, navigate]);
 

--- a/src/pages/SidePage.tsx
+++ b/src/pages/SidePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useLocation, useBlocker } from 'react-router-dom';
 import Flex from '../components/Flex';
 import trash from '../img/delete2.png';
@@ -24,14 +24,17 @@ import {
 import { useSidePage } from '../hooks/useSidePage';
 import { BlockNoteView } from '@blocknote/mantine';
 import useInterval from '../hooks/useInterval';
+import { getPersonalBlock } from '../api/PersonalBlockApi';
+import { BlockListResDto } from '../types/PersonalBlock';
 
 const SidePage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { highlightColor, progress } = location.state || {};
+  const blockId = location.pathname.split('/').pop();
 
-  const { data, handleTitleChange, onDateChange, onChange, editor, SubmitData } =
-    useSidePage(progress);
+  const { data, handleTitleChange, handleDateChange, onChange, editor, SubmitData, parseDate } =
+    useSidePage(blockId, progress);
 
   const toggleFunc = (event: React.MouseEvent) => {
     // SubmitData();
@@ -107,22 +110,23 @@ const SidePage = () => {
         {/* 날짜 및 시간 설정 */}
         <DateContainer>
           <Flex justifyContent="space-between">
-            <D_Day>D-10</D_Day>
+            <D_Day>D-{data.dDay}</D_Day>
             <StyledDatePicker>
               <DatePicker
-                selected={data.startDate}
-                onChange={(date: Date | null) => onDateChange(date, 'start')}
+                selected={parseDate(data.startDate)}
+                onChange={(date: Date | null) => handleDateChange(date, 'start')}
                 showTimeSelect
                 dateFormat="yyyy.MM.dd HH:mm"
                 timeIntervals={10} // 10분 간격으로 시간 선택
               />
               <p>~</p>
               <DatePicker
-                selected={data.endDate}
-                onChange={(date: Date | null) => onDateChange(date, 'end')}
+                selected={parseDate(data.deadLine)}
+                onChange={(date: Date | null) => handleDateChange(date, 'end')}
                 showTimeSelect
                 dateFormat="yyyy.MM.dd HH:mm"
                 timeIntervals={10} // 10분 간격으로 시간 선택
+                minDate={data.startDate ? new Date(data.startDate) : undefined}
               />
             </StyledDatePicker>
             <ImgWrapper src={trash} alt="휴지통 버튼" />

--- a/src/styles/DashboardStyled.tsx
+++ b/src/styles/DashboardStyled.tsx
@@ -25,6 +25,7 @@ export const DashboardItem = styled.article`
   color: ${theme.color.gray};
   font-weight: ${theme.font.weight.medium};
   margin-bottom: 0.8125rem;
+  cursor: pointer;
 `;
 
 export const CardContainer = styled.div<Props>`

--- a/src/styles/SidePageStyled.tsx
+++ b/src/styles/SidePageStyled.tsx
@@ -93,7 +93,7 @@ export const D_Day = styled.p`
 `;
 
 export const StyledDatePicker = styled.div`
-  width: 50vw;
+  width: 40vw;
   display: flex;
   align-items: center;
 

--- a/src/types/Columns.ts
+++ b/src/types/Columns.ts
@@ -1,0 +1,18 @@
+// types/Columns.ts
+import { BlockListResDto } from './PersonalBlock';
+
+export type DashboardProps = {
+  id: string;
+  list: BlockListResDto[];
+  component: React.FC<{ list: BlockListResDto[]; id: string }>;
+  backGroundColor: string;
+  highlightColor: string;
+  progress: string;
+  imgSrc: string;
+};
+
+export type Columns = {
+  todo: DashboardProps;
+  doing: DashboardProps;
+  done: DashboardProps;
+};

--- a/src/types/PersonalBlock.ts
+++ b/src/types/PersonalBlock.ts
@@ -1,7 +1,23 @@
-export interface PersonalBlock {
-  dashboardId: number;
-  title: string;
-  contents: string;
-  progress: string;
-  deadLine: string;
+export interface StatusPersonalBlock {
+  blockListResDto: BlockListResDto[];
+  pageInfoResDto: PageInfoResDto;
+}
+
+export interface BlockListResDto {
+  dashboardId?: string; // 지우) 따로 추가
+  blockId?: string | null;
+  title?: string;
+  contents?: string;
+  progress?: string;
+  type?: string;
+  startDate?: string | null;
+  deadLine?: string | null;
+  nickname?: string;
+  dDay?: number;
+}
+
+export interface PageInfoResDto {
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
 }

--- a/src/types/PersonalDashBoard.tsx
+++ b/src/types/PersonalDashBoard.tsx
@@ -16,7 +16,7 @@ export interface DashboardItem {
   blockProgress: number;
 }
 
-interface PageInfo {
+export interface PageInfo {
   currentPage: number;
   totalPages: number;
   totalItems: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10184,6 +10184,11 @@ react-icons@^5.2.1:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.3.0.tgz#ccad07a30aebd40a89f8cfa7d82e466019203f1c"
   integrity sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==
 
+react-intersection-observer@^9.13.0:
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.13.0.tgz#ee10827954cf6ccc204d027f8400a6ddb8df163a"
+  integrity sha512-y0UvBfjDiXqC8h0EWccyaj4dVBWMxgEx0t5RGNzQsvkfvZwugnKwxpu70StY4ivzYuMajavwUDjH4LJyIki9Lw==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -11176,7 +11181,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11287,7 +11301,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12615,7 +12636,16 @@ workbox-window@6.6.1:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## 🪄 목적

> 관련 이슈 : #26 

<br />
<br />

## 💻 상세 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 개인 대시보드 블록 get 요청 ('시작 전' 대시보드만 적용)
- 개인 대시보드 블록에 세로 무한 스크롤 적용
- 개인 대시보드 블록 생성 & 자동 저장
- 개인 대시보드 블록 내용 get 요청

<br />
<br />

## 📸 스크린샷
![개인 대시보드 블록 생성](https://github.com/user-attachments/assets/d4cc6dde-9416-419f-9916-30d89398f0ff)
![세로 무한 스크롤](https://github.com/user-attachments/assets/c15ac092-44a0-4b4a-8e20-f479acaa2a63)
![자동저장](https://github.com/user-attachments/assets/79f6dcb9-f0c0-4bf4-9397-0d21d6d6cd9a)

<br />
<br />

## 👼🏻 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.


이번 작업에서 타입 불일치 오류와 컴포넌트 사이의 복잡한 의존성 문제가 많았습니다.
이때 체계적인 컴포넌트 설계의 필요성을 느꼈고, 지금까지 사용된 컴포넌트의 관계들을 문서화하고 앞으로 컴포넌트 설계 후 작업을 시작하면 좋을 것 같습니다.