### PR TITLE
개인 대시보드 확인 및 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ const router = createBrowserRouter(
       <Route path="/api/oauth2/callback/:provider" element={<OAuthRedirectHandler />} />
       <Route path="/createBoard" element={<CreateBoard />} />
       <Route path="/createPersonalBoard" element={<CreatePersonalBoard />} />
+      <Route path="/createPersonalBoard/:id" element={<CreatePersonalBoard />} />
       <Route path="/createTeamBoard" element={<CreateTeamBoard />} />
       <Route path="/mypage" element={<MyPage />} />
       <Route path="/teamdocument" element={<TeamDocument />} />

--- a/src/api/BoardApi.tsx
+++ b/src/api/BoardApi.tsx
@@ -45,3 +45,13 @@ export const searchTeamDashBoard = async (): Promise<TeamDashboardResponse | und
     console.error('Error fetching data:', error);
   }
 };
+
+export const getCategories = async (): Promise<string[] | null> => {
+  try {
+    const response = await axiosInstance.get(`/dashboards/personal/categories`);
+    return response.data.data.categories;
+  } catch (error) {
+    console.log('error');
+    return null;
+  }
+};

--- a/src/api/BoardApi.tsx
+++ b/src/api/BoardApi.tsx
@@ -1,7 +1,7 @@
 import { axiosInstance } from '../utils/apiConfig';
 import {
   DashboardItem,
-  PersonalDashBoard,
+  // PersonalDashBoard,
   PersonalSearchDashBoard,
 } from '../types/PersonalDashBoard';
 import { TeamDashboardResponse } from '../types/TeamDashBoard';
@@ -25,12 +25,29 @@ export const getPersonalBlock = async (
 };
 
 // * 개인 대시보드 create
-export const createDashBoard = async (data: PersonalDashBoard): Promise<void> => {
+export const createDashBoard = async (data: DashboardItem): Promise<string | null> => {
   try {
     const response = await axiosInstance.post('/dashboards/personal/', data);
     console.log(response.data);
+    return response.data.data.dashboardId;
   } catch (error) {
     console.error('Error fetching data:', error);
+    return null;
+  }
+};
+
+// * 개인 대시보드 patch
+export const patchDashBoard = async (
+  dashboardId: string,
+  data: DashboardItem
+): Promise<string | null> => {
+  try {
+    const response = await axiosInstance.patch(`/dashboards/personal/${dashboardId}`, data);
+    console.log(response);
+    return response.data.data.dashboardId;
+  } catch (error) {
+    console.error('Error fetching data:', error);
+    return null;
   }
 };
 

--- a/src/api/BoardApi.tsx
+++ b/src/api/BoardApi.tsx
@@ -1,9 +1,14 @@
 import { axiosInstance } from '../utils/apiConfig';
-import { PersonalDashBoard, PersonalSearchDashBoard } from '../types/PersonalDashBoard';
+import {
+  DashboardItem,
+  PersonalDashBoard,
+  PersonalSearchDashBoard,
+} from '../types/PersonalDashBoard';
 import { TeamDashboardResponse } from '../types/TeamDashBoard';
 import { StatusPersonalBlock } from '../types/PersonalBlock';
 
-export const getDashBoard = async (
+// * 개인 대시보드 블록 get (세로 무한 스크롤)
+export const getPersonalBlock = async (
   id: number | string,
   page: number = 0, // default 페이지 0으로 설정
   size: number = 10
@@ -19,6 +24,7 @@ export const getDashBoard = async (
   }
 };
 
+// * 개인 대시보드 create
 export const createDashBoard = async (data: PersonalDashBoard): Promise<void> => {
   try {
     const response = await axiosInstance.post('/dashboards/personal/', data);
@@ -46,10 +52,22 @@ export const searchTeamDashBoard = async (): Promise<TeamDashboardResponse | und
   }
 };
 
+// * 개인 대시보드 생성시 사용자 카테고리 get
 export const getCategories = async (): Promise<string[] | null> => {
   try {
     const response = await axiosInstance.get(`/dashboards/personal/categories`);
     return response.data.data.categories;
+  } catch (error) {
+    console.log('error');
+    return null;
+  }
+};
+
+// * 개인 대시보드 상세 정보 get
+export const getPersonalDashboard = async (id: string): Promise<DashboardItem | null> => {
+  try {
+    const response = await axiosInstance.get(`/dashboards/personal/${id}`);
+    return response.data.data;
   } catch (error) {
     console.log('error');
     return null;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useLocation } from 'react-router-dom';
-import { getDashBoard } from '../api/BoardApi';
+// import { getPersonalBlock } from '../api/BoardApi';
 import * as S from '../styles/DashboardStyled';
 import { DashboardItem } from '../types/PersonalDashBoard';
 import { TeamDashboardInfoResDto } from '../types/TeamDashBoard';

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -1,10 +1,14 @@
 import * as S from '../styles/DashboardStyled';
 
-const Graph = () => {
+type GraphProps = {
+  blockProgress: number;
+};
+
+const Graph = ({ blockProgress }: GraphProps) => {
   return (
     <S.GraphContainer>
-      <S.GraphProgress>
-        <p>60%</p>
+      <S.GraphProgress blockProgress={blockProgress}>
+        <p>{blockProgress}%</p>
       </S.GraphProgress>
     </S.GraphContainer>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,13 +5,15 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import addbutton from '../img/addbutton.png';
 import leftarrow from '../img/leftarrow.png';
 import * as S from '../styles/HeaderStyled';
+import { dashboardType } from '../contexts/DashboardAtom';
 
 type Props = {
   mainTitle: string;
   subTitle: string;
+  blockProgress: number;
 };
 
-const Header = ({ mainTitle, subTitle }: Props) => {
+const Header = ({ mainTitle, subTitle, blockProgress }: Props) => {
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -20,13 +22,14 @@ const Header = ({ mainTitle, subTitle }: Props) => {
   };
 
   // URL에 "teamdocument"가 포함되어 있는지 확인하는 함수
-  const teamLocationUrl = location.pathname.includes('teamdocument') ?? true;
+  // => 전역 변수로 개인 대시보드인지 팀 대시보드인지 확인할 예정이라 주석 처리
+  // const teamLocationUrl = location.pathname.includes('teamdocument') ?? true;
   return (
     <>
       <Flex justifyContent="space-between" gap={100} margin="0 0 0.875rem 0">
         <S.HeaderContentContainer>
           <Flex alignItems="flex-start">
-            {teamLocationUrl && (
+            {!dashboardType && (
               <S.LeftArrowWrapper>
                 <img src={leftarrow} onClick={handleBackClick} />
               </S.LeftArrowWrapper>
@@ -34,26 +37,22 @@ const Header = ({ mainTitle, subTitle }: Props) => {
             <div>
               <Flex margin="0px 0px 6px 0px">
                 <S.TitleWrapper>{mainTitle}</S.TitleWrapper>
-                {!teamLocationUrl && (
-                  <S.SettingImgWrapper>
-                    <img src={setting} alt="설정 이미지" />
-                  </S.SettingImgWrapper>
-                )}
+                <S.SettingImgWrapper>
+                  <img src={setting} alt="설정 이미지" />
+                </S.SettingImgWrapper>
               </Flex>
               <S.SubtitleWrapper>{subTitle}</S.SubtitleWrapper>
             </div>
           </Flex>
         </S.HeaderContentContainer>
         <Flex>
-          {!teamLocationUrl && (
-            <>
-              <Graph />
-              <Link to="/teamdocument">
-                <S.TeamDocButton>팀문서</S.TeamDocButton>
-              </Link>
-            </>
+          <Graph blockProgress={blockProgress} />
+          {!dashboardType && (
+            <Link to="/teamdocument">
+              <S.TeamDocButton>팀문서</S.TeamDocButton>
+            </Link>
           )}
-          {teamLocationUrl && (
+          {!dashboardType && (
             <S.AddbuttonWrapper>
               <img src={addbutton}></img>
             </S.AddbuttonWrapper>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,6 +16,7 @@ type Props = {
 const Header = ({ mainTitle, subTitle, blockProgress }: Props) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const dashboardId = location.pathname.split('/')[1];
 
   const handleBackClick = () => {
     navigate(-1);
@@ -38,7 +39,9 @@ const Header = ({ mainTitle, subTitle, blockProgress }: Props) => {
               <Flex margin="0px 0px 6px 0px">
                 <S.TitleWrapper>{mainTitle}</S.TitleWrapper>
                 <S.SettingImgWrapper>
-                  <img src={setting} alt="설정 이미지" />
+                  <Link to={`/createPersonalBoard/${dashboardId}`}>
+                    <img src={setting} alt="설정 이미지" />
+                  </Link>
                 </S.SettingImgWrapper>
               </Flex>
               <S.SubtitleWrapper>{subTitle}</S.SubtitleWrapper>

--- a/src/contexts/DashboardAtom.ts
+++ b/src/contexts/DashboardAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const dashboardType = atom<boolean>(true); // true: 개인, false: 팀

--- a/src/hooks/usePersonalDashBoard.tsx
+++ b/src/hooks/usePersonalDashBoard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createDashBoard } from '../api/BoardApi';
 import { PersonalDashBoard, PersonalSearchDashBoard } from '../types/PersonalDashBoard';
-import { searchPersonalDashBoard } from '../api/BoardApi';
+import { searchPersonalDashBoard, getCategories } from '../api/BoardApi';
 import useModal from './useModal';
 
 /*
@@ -15,20 +15,23 @@ const usePersonalDashBoard = () => {
     isPublic: false,
     category: '',
   });
-  const [customCategory, setCustomCategory] = useState<string>(''); // 카테고리 옵션 중 '직접 입력' 선택시 입력 받을 커스텀 카테고리
   const { isModalOpen, openModal, closeModal } = useModal(); // 모달창 관련 훅 호출
   const navigate = useNavigate(); // 페이지 이동을 위한 훅
+
+  // * 사용자 대시보드 해시태그 불러오기
+  const getCategory = () => {
+    getCategories();
+  };
+
+  useEffect(() => {
+    getCategory();
+  }, []);
 
   // input 데이터 설정 함수 (제목, 설명, 카테고리 - 직접 입력)
   const handleChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
   ) => {
     const { name, value } = event.target;
-
-    // 예외처리 : 카테고리 직접 입력 후, 다른 카테고리 옵션 선택 후 다시 직접 입력하려 했을 때 빈 창으로 만들기 위해
-    if (name === 'category' && value !== 'userInput') {
-      setCustomCategory('');
-    }
 
     setFormData(prevState => ({ ...prevState, [name]: value }));
   };
@@ -41,35 +44,19 @@ const usePersonalDashBoard = () => {
     }));
   };
 
-  // 카테고리 설정 함수
-  const handleCustomCategoryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setCustomCategory(event.target.value);
-  };
-
-  // 오잉?
+  // 제출시 빈 칸이 있나 확인하는 함수 (있다면 true)
   const validateFormData = (formData: PersonalDashBoard): boolean => {
     return Object.values(formData).some(value => value === '');
   };
 
   // 대시보드 생성(제출) 함수
   const submitDashboard = async () => {
-    // 최종 제출시, 직접 입력으로 사용자가 카테고리를 입력했다면 해당 내용으로 제출 데이터 수정
-    // formData.category에 직접 설정할 수 없는 이유 : formData.category에 customCategory를 연결하면, 현재 input창이 'userInput'의 옵션이 선택될 때만 등장하도록 설정해뒀기 떄문에.
-    let finalCategory = formData.category;
-    if (formData.category === 'userInput' && !customCategory) {
-      finalCategory = '';
-    } else if (formData.category === 'userInput') {
-      finalCategory = customCategory;
-    }
-
-    const finalFormData = { ...formData, category: finalCategory };
-
     // 빈 작성란이 있으면 모달창 띄우기. 모두 작성되었으면 최종 제출
-    if (validateFormData(finalFormData)) {
+    if (validateFormData(formData)) {
       openModal();
     } else {
       try {
-        await createDashBoard(finalFormData);
+        await createDashBoard(formData);
         navigate('/');
       } catch (error) {
         console.error('개인 대시보드 생성시 오류 발생!', error);
@@ -79,11 +66,9 @@ const usePersonalDashBoard = () => {
 
   return {
     formData,
-    customCategory,
     isModalOpen,
     handleChange,
     handleScopeToggle,
-    handleCustomCategoryChange,
     submitDashboard,
     closeModal,
   };

--- a/src/hooks/usePersonalDashBoard.tsx
+++ b/src/hooks/usePersonalDashBoard.tsx
@@ -16,11 +16,13 @@ const usePersonalDashBoard = () => {
     category: '',
   });
   const { isModalOpen, openModal, closeModal } = useModal(); // 모달창 관련 훅 호출
+  const [categoryList, setCategoryList] = useState<string[]>([]);
   const navigate = useNavigate(); // 페이지 이동을 위한 훅
 
   // * 사용자 대시보드 해시태그 불러오기
-  const getCategory = () => {
-    getCategories();
+  const getCategory = async () => {
+    const list = await getCategories();
+    setCategoryList(list ?? []); // getCategories에서 null이 반한되었을 때는 빈 배열로 설정
   };
 
   useEffect(() => {
@@ -66,6 +68,7 @@ const usePersonalDashBoard = () => {
 
   return {
     formData,
+    categoryList,
     isModalOpen,
     handleChange,
     handleScopeToggle,

--- a/src/pages/CreatePersonalBoardPage.tsx
+++ b/src/pages/CreatePersonalBoardPage.tsx
@@ -24,16 +24,8 @@ import {
 } from '../styles/CreateBoardPageStyled';
 
 const CreatePersonalBoard = () => {
-  const {
-    formData,
-    customCategory,
-    isModalOpen,
-    handleChange,
-    handleScopeToggle,
-    handleCustomCategoryChange,
-    submitDashboard,
-    closeModal,
-  } = usePersonalDashBoard(); // 개인 대시보드 생성 커스텀 훅 사용
+  const { formData, isModalOpen, handleChange, handleScopeToggle, submitDashboard, closeModal } =
+    usePersonalDashBoard(); // 개인 대시보드 생성 커스텀 훅 사용
 
   return (
     <CreateDashBoardLayout>
@@ -44,17 +36,49 @@ const CreatePersonalBoard = () => {
           <SubTitle>제목과 설명, 카테고리를 설정하고 공개 여부를 선택하세요.</SubTitle>
 
           <CreateForm>
+            <RowWrapper>
+              <Label>제목</Label>
+              <Input
+                type="text"
+                name="title"
+                placeholder="대시보드 제목을 설정해주세요."
+                width="27.1rem"
+                value={formData.title}
+                onChange={handleChange}
+              />
+            </RowWrapper>
+
+            <RowWrapper>
+              <Label>설명</Label>
+              <Textarea
+                name="description"
+                placeholder="대시보드 설명을 설정해주세요."
+                width="27.1rem"
+                maxLength={300}
+                value={formData.description}
+                onChange={handleChange}
+              />
+            </RowWrapper>
+
+            {/* TODO: 사용자 카테고리 받아오기 */}
             <Flex>
               <RowWrapper>
-                <Label>제목</Label>
+                <Label>카테고리</Label>
                 <Input
                   type="text"
-                  name="title"
-                  placeholder="대시보드 제목을 설정해주세요."
+                  name="category"
+                  placeholder="대시보드 카테고리를 설정해주세요."
                   width="20rem"
-                  value={formData.title}
+                  list="categoryList"
+                  value={formData.category}
                   onChange={handleChange}
                 />
+                <datalist id="categoryList">
+                  <option value="해시" />
+                  <option value="태그" />
+                  <option value="오지" />
+                  <option value="않는" />
+                </datalist>
               </RowWrapper>
 
               <RowWrapper onClick={handleScopeToggle}>
@@ -71,40 +95,6 @@ const CreatePersonalBoard = () => {
                 )}
               </RowWrapper>
             </Flex>
-
-            <RowWrapper>
-              <Label>설명</Label>
-              <Textarea
-                name="description"
-                placeholder="대시보드 설명을 설정해주세요."
-                width="27.1rem"
-                maxLength={300}
-                value={formData.description}
-                onChange={handleChange}
-              />
-            </RowWrapper>
-
-            <RowWrapper>
-              <Label>카테고리</Label>
-              <Select name="category" value={formData.category} onChange={handleChange}>
-                <option hidden selected>
-                  (선택) 카테고리를 설정해주세요.
-                </option>
-                <option value="nothing">카테고리 없음</option>
-                <option value="userInput">직접 입력</option>
-              </Select>
-              {/* 직접 입력시 input창 등장 */}
-              {formData.category === 'userInput' && (
-                <Input
-                  type="text"
-                  name="category"
-                  placeholder="카테고리 이름을 설정해주세요."
-                  width="12.7rem"
-                  value={customCategory}
-                  onChange={handleCustomCategoryChange}
-                />
-              )}
-            </RowWrapper>
           </CreateForm>
 
           <SubmitBtn onClick={submitDashboard}>대시보드 생성</SubmitBtn>

--- a/src/pages/CreatePersonalBoardPage.tsx
+++ b/src/pages/CreatePersonalBoardPage.tsx
@@ -24,8 +24,15 @@ import {
 } from '../styles/CreateBoardPageStyled';
 
 const CreatePersonalBoard = () => {
-  const { formData, isModalOpen, handleChange, handleScopeToggle, submitDashboard, closeModal } =
-    usePersonalDashBoard(); // 개인 대시보드 생성 커스텀 훅 사용
+  const {
+    formData,
+    categoryList,
+    isModalOpen,
+    handleChange,
+    handleScopeToggle,
+    submitDashboard,
+    closeModal,
+  } = usePersonalDashBoard(); // 개인 대시보드 생성 커스텀 훅 사용
 
   return (
     <CreateDashBoardLayout>
@@ -74,10 +81,9 @@ const CreatePersonalBoard = () => {
                   onChange={handleChange}
                 />
                 <datalist id="categoryList">
-                  <option value="해시" />
-                  <option value="태그" />
-                  <option value="오지" />
-                  <option value="않는" />
+                  {categoryList.map((category, index) => (
+                    <option key={index} value={category} />
+                  ))}
                 </datalist>
               </RowWrapper>
 

--- a/src/pages/CreatePersonalBoardPage.tsx
+++ b/src/pages/CreatePersonalBoardPage.tsx
@@ -22,8 +22,12 @@ import {
   Scope,
   Textarea,
 } from '../styles/CreateBoardPageStyled';
+import { useLocation } from 'react-router-dom';
 
 const CreatePersonalBoard = () => {
+  const location = useLocation();
+  let dashboardId = location.pathname.split('/').pop() || null;
+  if (dashboardId === 'createPersonalBoard') dashboardId = null; // dashboard 첫 생성시 dashboard id 값을 null로 만들어 줌
   const {
     formData,
     categoryList,
@@ -32,14 +36,14 @@ const CreatePersonalBoard = () => {
     handleScopeToggle,
     submitDashboard,
     closeModal,
-  } = usePersonalDashBoard(); // 개인 대시보드 생성 커스텀 훅 사용
+  } = usePersonalDashBoard(dashboardId); // 개인 대시보드 생성 커스텀 훅 사용
 
   return (
     <CreateDashBoardLayout>
       <Navbar />
       <CreateDashBoardContainer>
         <CreateDashBoardModal>
-          <Title>개인 대시보드 생성</Title>
+          <Title>개인 대시보드 {dashboardId ? '수정' : '생성'}</Title>
           <SubTitle>제목과 설명, 카테고리를 설정하고 공개 여부를 선택하세요.</SubTitle>
 
           <CreateForm>
@@ -103,7 +107,7 @@ const CreatePersonalBoard = () => {
             </Flex>
           </CreateForm>
 
-          <SubmitBtn onClick={submitDashboard}>대시보드 생성</SubmitBtn>
+          <SubmitBtn onClick={submitDashboard}>대시보드 {dashboardId ? '수정' : '생성'}</SubmitBtn>
         </CreateDashBoardModal>
       </CreateDashBoardContainer>
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -13,8 +13,9 @@ import { useEffect, useState } from 'react';
 import { handleAutoScroll } from '../utils/handleAutoScroll';
 import { useBlocker, useLocation } from 'react-router-dom';
 import { StatusPersonalBlock } from '../types/PersonalBlock';
-import { getDashBoard } from '../api/BoardApi';
+import { getPersonalBlock, getPersonalDashboard } from '../api/BoardApi';
 import ComponentStyle from 'styled-components/dist/models/ComponentStyle';
+import { DashboardItem } from '../types/PersonalDashBoard';
 
 export type TItemStatus = 'todo' | 'doing' | 'done';
 
@@ -24,6 +25,7 @@ const MainPage = () => {
 
   const [page, setPage] = useState<number>(0);
 
+  const [dashboardDetail, setDashboardDetail] = useState<DashboardItem>();
   const [columns, setColumns] = useState<{
     [key in TItemStatus]: {
       id: string;
@@ -82,12 +84,13 @@ const MainPage = () => {
       },
     }));
 
-    fetchData(0);
+    fetchBlockData(0);
+    fetchDashboardData();
   }, [location.pathname]); // 라우터 변경 감지
 
   // * get 대시보드 블록
-  const fetchData = async (page: number = 0) => {
-    const data = await getDashBoard(dashboardId, page, 10);
+  const fetchBlockData = async (page: number = 0) => {
+    const data = await getPersonalBlock(dashboardId, page, 10);
 
     if (data) {
       // setNotStartedBlocks(data);
@@ -111,7 +114,7 @@ const MainPage = () => {
 
   // useEffect로 페이지가 변경될 때 데이터를 다시 가져오도록 설정
   useEffect(() => {
-    fetchData(page);
+    fetchBlockData(page);
   }, [page]); // page가 변경될 때마다 fetchData 실행
 
   // * 드래그 앤 드롭
@@ -157,11 +160,24 @@ const MainPage = () => {
     }
   };
 
+  // * 개인 대시보드 상세 정보 get
+  const fetchDashboardData = async () => {
+    const data = await getPersonalDashboard(dashboardId);
+    setDashboardDetail(data ?? undefined); // getPersonalDashboard가 null 반환시 undefined로 설정
+  };
+
+  /*
+  ! 추후 비즈니스 로직은 훅으로 정리할 예정
+  */
+
   return (
     <S.MainDashBoardLayout>
       <Navbar />
       <S.MainDashBoardContainer>
-        <Header mainTitle="개인 대시보드" subTitle="개인 대시보드 설명하는 자리입니다" />
+        <Header
+          mainTitle={dashboardDetail?.title || '개인 대시보드'}
+          subTitle={dashboardDetail?.description || '개인 대시보드 설명'}
+        />
         <DragDropContext onDragEnd={onDragEnd} onDragUpdate={handleAutoScroll}>
           <S.CardContainer>
             {Object.values(columns).map(column => {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -16,6 +16,8 @@ import { StatusPersonalBlock } from '../types/PersonalBlock';
 import { getPersonalBlock, getPersonalDashboard } from '../api/BoardApi';
 import ComponentStyle from 'styled-components/dist/models/ComponentStyle';
 import { DashboardItem } from '../types/PersonalDashBoard';
+import { useAtom } from 'jotai';
+import { dashboardType } from '../contexts/DashboardAtom';
 
 export type TItemStatus = 'todo' | 'doing' | 'done';
 
@@ -177,6 +179,7 @@ const MainPage = () => {
         <Header
           mainTitle={dashboardDetail?.title || '개인 대시보드'}
           subTitle={dashboardDetail?.description || '개인 대시보드 설명'}
+          blockProgress={dashboardDetail?.blockProgress || 0}
         />
         <DragDropContext onDragEnd={onDragEnd} onDragUpdate={handleAutoScroll}>
           <S.CardContainer>

--- a/src/pages/TeamDocument.tsx
+++ b/src/pages/TeamDocument.tsx
@@ -31,6 +31,7 @@ const TeamDocument = () => {
         <Header
           mainTitle="팀 문서"
           subTitle="팀 대시보드의 설명이 동일하게 이 위치에도 적용됩니다"
+          blockProgress={50}
         />
         <S.FolderEntireContainer>
           <Flex gap="4.5625rem">

--- a/src/pages/TeamFileBoard.tsx
+++ b/src/pages/TeamFileBoard.tsx
@@ -15,7 +15,7 @@ const TeamFileBoard = () => {
     <S.MainDashBoardLayout>
       <Navbar />
       <S.MainDashBoardContainer>
-        <Header mainTitle="기획" subTitle="기획을 설명해주세요" />
+        <Header mainTitle="기획" subTitle="기획을 설명해주세요" blockProgress={50} />
         <FolderContainer>
           <Flex gap="4.5625rem">
             <File caption="기능명세서" />

--- a/src/styles/DashboardStyled.tsx
+++ b/src/styles/DashboardStyled.tsx
@@ -96,8 +96,9 @@ export const GraphContainer = styled.div`
   }
 `;
 
-export const GraphProgress = styled.div`
-  width: 60%; /*todo의 완료도에 따라 부모 width의 퍼센테이지로 맞춰 크기 조정*/
+export const GraphProgress = styled.div<{ blockProgress: number }>`
+  width: ${({ blockProgress }) =>
+    blockProgress}%; /*todo의 완료도에 따라 부모 width의 퍼센테이지로 맞춰 크기 조정*/
   height: 1.3125rem;
 
   background: ${theme.color.gradation};

--- a/src/types/PersonalDashBoard.tsx
+++ b/src/types/PersonalDashBoard.tsx
@@ -1,19 +1,19 @@
-export interface PersonalDashBoard {
-  title: string;
-  description: string;
-  isPublic: boolean;
-  category: string | undefined;
-}
+// export interface PersonalDashBoard {
+//   title: string;
+//   description: string;
+//   isPublic: boolean;
+//   category: string | undefined;
+// }
 
 export interface DashboardItem {
-  dashboardId: number | null;
-  myId: number | null;
-  creatorId: number | null;
+  dashboardId?: number | null;
+  myId?: number | null;
+  creatorId?: number | null;
   title: string;
   description: string;
   isPublic: boolean;
   category: string;
-  blockProgress: number;
+  blockProgress?: number;
 }
 
 export interface PageInfo {


### PR DESCRIPTION
## 🪄 목적

> 관련 이슈 : #30

<br />
<br />

## 💻 상세 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 개인 대시보드 생성시 사용자 카테고리를 받아와 보여줍니다.
  - 기존 방식은 selectbox로 옵션을 선택하고, 새로운 카테고리 추가시 '직접 입력'의 옵션을 선택하는 방식이었지만, 
  - input과 datalist 태그를 사용해 사용자 카테고리를 제공하고 자동완성 기능을 제공하여 보다 쉽게 카테고리를 설정할 수 있도록 수정하였습니다.
- 대시보드 페이지에서 대시보드 정보를 확인합니다.
- 대시보드 정보를 수정합니다.

<br />
<br />

## 📸 스크린샷
![대시보드 정보 불러오고 수정](https://github.com/user-attachments/assets/fa4aa189-842e-493b-a4fd-90a7e08eb58c)
![카테고리 방식 변경](https://github.com/user-attachments/assets/a3422843-8a8f-4fe0-a158-4605b9351f04)


<br />
<br />

## 👼🏻 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
