### PR TITLE
navbar 개인 대시보드에 카테고리 분류 적용

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,36 +3,85 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import * as S from '../styles/DashboardStyled';
 import { DashboardItem } from '../types/PersonalDashBoard';
 import { TeamDashboardInfoResDto } from '../types/TeamDashBoard';
+import { useEffect, useState } from 'react';
 
 interface Props {
   text: string;
   dashboard?: DashboardItem[] | TeamDashboardInfoResDto[];
 }
+
+interface GroupedDashboards {
+  [category: string]: DashboardItem[];
+}
+
 const Dashboard = ({ text, dashboard }: Props) => {
   const navigate = useNavigate();
   const location = useLocation();
   const id = location.pathname.split('/')[1];
+  const [groupedDashboard, setGroupedDashboard] = useState<GroupedDashboards>({});
 
   const onClick = (id: number | string) => {
     navigate(`/${id}`);
     localStorage.setItem('LatestBoard', String(id));
   };
 
+  const groupByCategory = (dashboardItems: DashboardItem[] | undefined): GroupedDashboards => {
+    if (!dashboardItems) {
+      return {}; // undefined일 경우 빈 객체 반환
+    }
+
+    return dashboardItems.reduce((acc, item) => {
+      const category = item.category;
+      if (!acc[category]) {
+        acc[category] = [];
+      }
+      acc[category].push(item);
+      return acc;
+    }, {} as GroupedDashboards);
+  };
+
+  useEffect(() => {
+    if (dashboard) {
+      const grouped = groupByCategory(dashboard as DashboardItem[]);
+      setGroupedDashboard(grouped);
+    }
+  }, [dashboard]);
+
   return (
-    <S.DashboardContainer>
+    <S.DashboardContainer text={text}>
       <h6>{text} 대시보드</h6>
-      <S.DashboardItemContainer>
-        {dashboard?.map((value, index) => (
-          <S.DashboardItem
-            key={index}
-            onClick={() => {
-              onClick(value.dashboardId ?? 0);
-            }}
-          >
-            {value.title}
-          </S.DashboardItem>
-        ))}
-      </S.DashboardItemContainer>
+      {text === '팀' ? (
+        // 팀 대시보드일 때 렌더링
+        <S.DashboardItemContainer>
+          {dashboard?.map((value, index) => (
+            <S.TeamDashboardItem
+              key={index}
+              onClick={() => {
+                onClick(value.dashboardId ?? 0);
+              }}
+            >
+              {value.title}
+            </S.TeamDashboardItem>
+          ))}
+        </S.DashboardItemContainer>
+      ) : (
+        // 개인 대시보드일 때 렌더링
+        Object.keys(groupedDashboard).map(category => (
+          <details key={category}>
+            <summary>{category}</summary>
+            <S.DashboardItemContainer>
+              {groupedDashboard[category].map(dashboardItem => (
+                <S.PersonalDashboardItem
+                  key={dashboardItem.dashboardId}
+                  onClick={() => onClick(dashboardItem.dashboardId ?? 0)}
+                >
+                  {dashboardItem.title}
+                </S.PersonalDashboardItem>
+              ))}
+            </S.DashboardItemContainer>
+          </details>
+        ))
+      )}
     </S.DashboardContainer>
   );
 };

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -21,16 +21,18 @@ const Dashboard = ({ text, dashboard }: Props) => {
   return (
     <S.DashboardContainer>
       <h6>{text} 대시보드</h6>
-      {dashboard?.map((value, index) => (
-        <S.DashboardItem
-          key={index}
-          onClick={() => {
-            onClick(value.dashboardId ?? 0);
-          }}
-        >
-          {value.title}
-        </S.DashboardItem>
-      ))}
+      <S.DashboardItemContainer>
+        {dashboard?.map((value, index) => (
+          <S.DashboardItem
+            key={index}
+            onClick={() => {
+              onClick(value.dashboardId ?? 0);
+            }}
+          >
+            {value.title}
+          </S.DashboardItem>
+        ))}
+      </S.DashboardItemContainer>
     </S.DashboardContainer>
   );
 };

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,6 +11,7 @@ const Navbar = () => {
   const { dashboard } = usePersonalDashBoardSearch();
   const { teamDashboard } = useTeamDashBoard();
   const { info } = useInfo();
+
   return (
     <S.NavBarLayout>
       <div>

--- a/src/styles/DashboardStyled.tsx
+++ b/src/styles/DashboardStyled.tsx
@@ -9,15 +9,23 @@ type Props = {
 };
 
 export const DashboardContainer = styled.section`
-  margin-bottom: 3.3125rem;
-  height: 100%;
+  /* margin-bottom: 3.3125rem; */
+  /* overflow: hidden; */
 
   h6 {
     font-size: 10px;
     font-weight: ${theme.font.weight.medium};
     color: ${theme.color.gray};
     margin-bottom: 1.25rem;
+    /* padding-top: 2rem; */
   }
+`;
+
+export const DashboardItemContainer = styled.div`
+  width: 100%;
+  /* background-color: red; */
+  /* height: 25vh;
+  overflow-y: scroll; */
 `;
 
 export const DashboardItem = styled.article`
@@ -26,6 +34,10 @@ export const DashboardItem = styled.article`
   font-weight: ${theme.font.weight.medium};
   margin-bottom: 0.8125rem;
   cursor: pointer;
+
+  &:last-child {
+    margin-bottom: 2rem;
+  }
 `;
 
 export const CardContainer = styled.div<Props>`

--- a/src/styles/DashboardStyled.tsx
+++ b/src/styles/DashboardStyled.tsx
@@ -1,5 +1,6 @@
 import { styled } from 'styled-components';
 import theme from '../styles/Theme/Theme';
+import rightArrowImg from '../img/rightarrow.png';
 
 type Props = {
   backGroundColor?: string;
@@ -7,37 +8,82 @@ type Props = {
   state?: string;
   imgSrc?: string;
 };
+interface DashboardContainerProps {
+  text: string;
+}
 
-export const DashboardContainer = styled.section`
+export const DashboardContainer = styled.section<DashboardContainerProps>`
   /* margin-bottom: 3.3125rem; */
   /* overflow: hidden; */
 
   h6 {
-    font-size: 10px;
+    font-size: 0.7rem;
     font-weight: ${theme.font.weight.medium};
     color: ${theme.color.gray};
-    margin-bottom: 1.25rem;
-    /* padding-top: 2rem; */
+    margin-bottom: 0.8rem;
+    ${props =>
+      props.text === '팀' &&
+      `
+      margin-top: 2rem; /* '팀'일 때 적용할 스타일 */
+    `}
+  }
+
+  summary {
+    list-style: none; /* 기본 아이콘 제거 */
+    font-size: ${theme.font.size.main};
+    color: ${theme.color.gray};
+    font-weight: ${theme.font.weight.medium};
+    cursor: pointer;
+    margin: 0.5rem 0;
+  }
+
+  summary::-webkit-details-marker {
+    display: none; /* 크롬/사파리 등의 브라우저에서 기본 아이콘 숨기기 */
+  }
+
+  summary::before {
+    content: '';
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    margin-right: 0.5rem;
+    background-image: url(${rightArrowImg});
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    transition: transform 0.3s ease;
+  }
+
+  /* 열렸을 때 summary의 스타일 변경 */
+  /* details[open] summary {
+    font-weight: ${theme.font.weight.bold}; 
+  } */
+
+  /* 열렸을 때의 스타일 */
+  details[open] summary::before {
+    transform: rotate(90deg); /* 열리면 아이콘 회전 */
   }
 `;
 
 export const DashboardItemContainer = styled.div`
   width: 100%;
-  /* background-color: red; */
-  /* height: 25vh;
-  overflow-y: scroll; */
 `;
 
-export const DashboardItem = styled.article`
+export const PersonalDashboardItem = styled.article`
   font-size: ${theme.font.size.main};
   color: ${theme.color.gray};
   font-weight: ${theme.font.weight.medium};
-  margin-bottom: 0.8125rem;
   cursor: pointer;
+  margin: 0.5rem 0;
+  margin-left: 2rem;
+`;
 
-  &:last-child {
-    margin-bottom: 2rem;
-  }
+export const TeamDashboardItem = styled.article`
+  font-size: ${theme.font.size.main};
+  color: ${theme.color.gray};
+  font-weight: ${theme.font.weight.medium};
+  cursor: pointer;
+  margin: 0.5rem 0;
 `;
 
 export const CardContainer = styled.div<Props>`

--- a/src/styles/NavBarStyled.tsx
+++ b/src/styles/NavBarStyled.tsx
@@ -42,7 +42,7 @@ export const UserDetailContainer = styled.div`
 export const ButtonContainer = styled.div`
   display: flex;
   flex-direction: column;
-  margin-bottom: 1.875rem;
+  margin-bottom: 2rem;
 `;
 
 export const DashboardsContainer = styled.div`


### PR DESCRIPTION
## 🪄 목적

> 관련 이슈 : #31

<br />
<br />

## 💻 상세 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- navbar에 대시보드 개수가 많아지면 스타일이 겹쳐지는 오류를 해결했습니다.
- navbar에 개인 대시보드 리스트에 카테고리별 토글 메뉴를 적용하였습니다.

<br />
<br />

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/4ac4c33f-d583-4e3b-8edd-00b239fdbe0b)

<br />
<br />

## 👼🏻 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
