### PR TITLE
팀 문서 삭제

### DIFF
--- a/src/api/TeamDocumentApi.ts
+++ b/src/api/TeamDocumentApi.ts
@@ -84,3 +84,12 @@ export const patchTeamDocument = async (data: TeamDocument): Promise<string | nu
     return null;
   }
 };
+
+// * 팀 문서 삭제 delete
+export const deleteTeamDocument = async (teamDocumentId: string): Promise<void> => {
+  try {
+    const response = await axiosInstance.delete(`/dashboards/team/document/${teamDocumentId}`);
+  } catch (error) {
+    console.error('Error fetching data:', error);
+  }
+};

--- a/src/pages/TeamDocument.tsx
+++ b/src/pages/TeamDocument.tsx
@@ -35,12 +35,15 @@ import { BlockListResDto } from '../types/PersonalBlock';
 import Navbar from '../components/Navbar';
 import useInfo from '../hooks/useInfo';
 import { deleteTeamDocument } from '../api/TeamDocumentApi';
+import useModal from '../hooks/useModal';
+import CustomModal from '../components/CustomModal';
 
 const TeamDocument = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const pathname = location.pathname;
   const segments = pathname.split('/');
+  const { isModalOpen, openModal, handleYesClick, handleNoClick } = useModal(); // 모달창 관련 훅 호출
 
   const teamDashboardId = segments[1]; // Assuming /48 is the teamDashboardId
   const teamDocumentId = segments[3]; // Assuming /15 is the teamDocumentId
@@ -80,6 +83,11 @@ const TeamDocument = () => {
     await deleteTeamDocument(teamDocumentId);
     navigate(`/${teamDashboardId}/teamdocument`);
   };
+
+  const submitDelTeamDocument = () => {
+    openModal('yes', delTeamDocument);
+  };
+
   return (
     <SideScreenContainer onClick={toggleFunc}>
       <SideScreen
@@ -99,7 +107,7 @@ const TeamDocument = () => {
               <S.DocumnetWriter>{info?.data.nickName}</S.DocumnetWriter>
             </Flex>
             {/* 팀 문서 삭제 */}
-            <DeleteIcon onClick={delTeamDocument}>
+            <DeleteIcon onClick={submitDelTeamDocument}>
               <img src={deleteIcon} alt="휴지통 아이콘" />
             </DeleteIcon>
           </Flex>
@@ -132,6 +140,15 @@ const TeamDocument = () => {
         <StyledEditorWrapper>
           <BlockNoteView editor={editor} onChange={onChange} />
         </StyledEditorWrapper>
+
+        {isModalOpen && (
+          <CustomModal
+            title="팀 문서를 삭제하시겠습니까?"
+            subTitle="한 번 삭제된 팀 문서는 되돌릴 수 없습니다."
+            onYesClick={handleYesClick}
+            onNoClick={handleNoClick}
+          />
+        )}
       </SideScreen>
     </SideScreenContainer>
   );

--- a/src/pages/TeamDocument.tsx
+++ b/src/pages/TeamDocument.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation, useBlocker } from 'react-router-dom';
 import Flex from '../components/Flex';
 import trash from '../img/delete2.png';
 import closebutton from '../img/closebutton.png';
+import deleteIcon from '../img/delete2.png';
 
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
@@ -23,6 +24,7 @@ import {
   CategoryContainer,
   InputCategory,
   RowWrapper,
+  DeleteIcon,
 } from '../styles/SidePageStyled';
 import * as S from '../styles/TeamDocumentStyled';
 import { useTeamDocument } from '../hooks/useTeamDocument';
@@ -32,6 +34,7 @@ import { getPersonalBlock } from '../api/PersonalBlockApi';
 import { BlockListResDto } from '../types/PersonalBlock';
 import Navbar from '../components/Navbar';
 import useInfo from '../hooks/useInfo';
+import { deleteTeamDocument } from '../api/TeamDocumentApi';
 
 const TeamDocument = () => {
   const navigate = useNavigate();
@@ -72,6 +75,11 @@ const TeamDocument = () => {
     return true;
   });
 
+  // * 팀 문서 삭제
+  const delTeamDocument = async () => {
+    await deleteTeamDocument(teamDocumentId);
+    navigate(`/${teamDashboardId}/teamdocument`);
+  };
   return (
     <SideScreenContainer onClick={toggleFunc}>
       <SideScreen
@@ -83,11 +91,17 @@ const TeamDocument = () => {
 
         {/* 제목 입력 */}
         <TitleContainer>
-          <Flex>
-            <S.DocumentWriterImg>
-              <img src={info?.data.picture} alt="프로필 사진" />
-            </S.DocumentWriterImg>
-            <S.DocumnetWriter>{info?.data.nickName}</S.DocumnetWriter>
+          <Flex justifyContent="space-between">
+            <Flex>
+              <S.DocumentWriterImg>
+                <img src={info?.data.picture} alt="프로필 사진" />
+              </S.DocumentWriterImg>
+              <S.DocumnetWriter>{info?.data.nickName}</S.DocumnetWriter>
+            </Flex>
+            {/* 팀 문서 삭제 */}
+            <DeleteIcon onClick={delTeamDocument}>
+              <img src={deleteIcon} alt="휴지통 아이콘" />
+            </DeleteIcon>
           </Flex>
           <Input
             type="text"

--- a/src/pages/TeamDocumentBoard.tsx
+++ b/src/pages/TeamDocumentBoard.tsx
@@ -73,7 +73,7 @@ const TeamDocumentBoard = () => {
     const newDocument: TeamDocument = {
       title: '',
       content: '',
-      category: '',
+      category: '카테고리 없음',
       teamDashboardId: dashboardId,
     };
 

--- a/src/styles/SidePageStyled.tsx
+++ b/src/styles/SidePageStyled.tsx
@@ -190,3 +190,23 @@ export const StyledEditorWrapper = styled.div`
     overflow-y: scroll;
   }
 `;
+
+export const DeleteIcon = styled.div`
+  width: 1.8rem;
+  height: 1.8rem;
+
+  border-radius: 50%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  img {
+    width: 1rem;
+    cursor: pointer;
+  }
+
+  &:hover {
+    background-color: ${theme.color.stroke2};
+  }
+`;


### PR DESCRIPTION
## 🪄 목적

> 관련 이슈 : #50

<br />
<br />

## 💻 상세 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 팀 문서를 사이드 페이지에서 삭제합니다.
- 드래그앤드롭으로 삭제하던 삭제 아이콘과 헷갈리지 않게 새로운 아이콘을 만들어 사용했습니다.
- 팀 문서 삭제시 확인 모달창을 추가했습니다.

<br />
<br />

## 📸 스크린샷

![팀 문서 삭제](https://github.com/user-attachments/assets/d1d145f4-7f5e-4822-9db0-3c25b2d9c5b9)
![팀 문서 삭제 모달창](https://github.com/user-attachments/assets/2fcc8e78-ae57-4fbc-832e-2c470d0d3dec)



<br />
<br />

## 👼🏻 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
