### PR TITLE
마이페이지 이용시 팀대시보드 생성 오류 수정

### DIFF
--- a/src/api/MyPageApi.ts
+++ b/src/api/MyPageApi.ts
@@ -1,10 +1,20 @@
-import { ProfileInfo } from '../types/MyPage';
+import { ProfileInfo, ReturnData } from '../types/MyPage';
 import { axiosInstance } from '../utils/apiConfig';
 
 export const fetchData = async (): Promise<ProfileInfo | undefined> => {
   try {
     const res = await axiosInstance.get('/members/mypage');
     return res.data as ProfileInfo;
+  } catch (error) {
+    console.error('Error fetching data:', error);
+  }
+};
+
+export const fetchBlockData = async (): Promise<ReturnData | undefined> => {
+  try {
+    const res = await axiosInstance.get('/members/mypage/dashboard-challenges');
+
+    return res.data as ReturnData;
   } catch (error) {
     console.error('Error fetching data:', error);
   }

--- a/src/pages/CreateTeamBoardPage.tsx
+++ b/src/pages/CreateTeamBoardPage.tsx
@@ -37,7 +37,7 @@ const CreateTeamBoard = () => {
   const navigate = useNavigate(); // 페이지 이동을 위한 훅
   const location = useLocation();
   let dashboardId = location.pathname.split('/').pop() || null;
-  if (dashboardId === 'createPersonalBoard') dashboardId = null; // dashboard 첫 생성시 dashboard id 값을 null로 만들어 줌
+  if (dashboardId === 'createTeamBoard') dashboardId = null; // dashboard 첫 생성시 dashboard id 값을 null로 만들어 줌
   const { isModalOpen, openModal, handleYesClick, handleNoClick } = useModal(); // 모달창 관련 훅 호출
   const [isDelModalOpen, setIsDelModalOpen] = useState<boolean>(false);
   const [isEmptyModalOpen, setIsEmptyModalOpen] = useState<boolean>(false);
@@ -46,6 +46,7 @@ const CreateTeamBoard = () => {
   const [formData, setFormData] = useState<TeamDashboardInfoResDto>({
     title: '',
     description: '',
+    invitedEmails: [],
   });
 
   // * 사용자 대시보드 해시태그 불러오기 & 대시보드 수정이라면 대시보드 상세 데이터 불러오기

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -4,15 +4,22 @@ import googleicon from '../img/googleicon.png';
 import kakaologo from '../img/kakaologo.png';
 import bell from '../img/bell.png';
 import ChallengeBlock from '../components/ChallengeBlock';
-import ReactPaginate from 'react-paginate';
 import * as S from '../styles/MyPageStyled';
 import Profile from '../components/Profile';
 import { useQuery } from '@tanstack/react-query';
-import { fetchData } from '../api/MyPageApi';
+import { fetchBlockData, fetchData } from '../api/MyPageApi';
+import { ChangeEvent, useState } from 'react';
+import Pagination from '@mui/material/Pagination';
+import { TeamDashboardInfoResDto } from '../types/TeamDashBoard';
 
 const MyPage = () => {
   const { data } = useQuery({ queryKey: ['profile'], queryFn: fetchData });
+  const { data: teamBlock } = useQuery({ queryKey: ['teamBlcok'], queryFn: fetchBlockData });
+
+  const [teamBool, setTeamBool] = useState<boolean>(true);
+
   const socialType = data?.data.socialType;
+
   const SocialIcon = () => (
     <S.GoogleImageIcon
       src={socialType === 'KAKAO' ? kakaologo : googleicon}
@@ -45,15 +52,21 @@ const MyPage = () => {
           </S.ImageWrapper>
         </Flex>
         <S.ChanllengeBlockContainer>
-          <ChallengeBlock />
-          <ChallengeBlock />
-          <ChallengeBlock />
-          <ChallengeBlock />
-          <ChallengeBlock />
-          <ChallengeBlock />
+          {teamBool
+            ? teamBlock?.data.teamDashboardList.teamDashboardInfoResDto.map((item, idx) => (
+                <ChallengeBlock key={idx} />
+              ))
+            : teamBlock?.data.challengeList.challengeInfoResDto.map((item, idx) => (
+                <ChallengeBlock key={idx} />
+              ))}
         </S.ChanllengeBlockContainer>
         <S.PagenateBox>
-          <ReactPaginate pageCount={6} pageRangeDisplayed={6} previousLabel="<" nextLabel=">" />
+          {/* <Pagination
+            page={teamPage}
+            count={teamBlock?.data.teamDashboardList.pageInfoResDto.totalPages}
+            defaultPage={1}
+            onChange={onChangePageNation}
+          /> */}
         </S.PagenateBox>
       </S.MyPageLayout>
     </Flex>

--- a/src/types/MyPage.ts
+++ b/src/types/MyPage.ts
@@ -10,3 +10,42 @@ export interface ProfileInfo {
     introduction: 'string';
   };
 }
+
+interface PageInfoResDto {
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+}
+
+interface TeamDashboardInfoResDto {
+  // 팀 대시보드 정보에 맞는 속성들을 추가해야 합니다. 예시로는 아래와 같이 비워둡니다.
+}
+
+interface ChallengeInfoResDto {
+  // 챌린지 정보에 맞는 속성들을 추가해야 합니다. 예시로는 아래와 같이 비워둡니다.
+}
+
+interface TeamDashboardList {
+  teamDashboardInfoResDto: TeamDashboardInfoResDto[];
+  pageInfoResDto: PageInfoResDto;
+}
+
+interface ChallengeList {
+  challengeInfoResDto: ChallengeInfoResDto[];
+  pageInfoResDto: PageInfoResDto;
+}
+
+interface ApiResponse {
+  statusCode: number;
+  message: string;
+  data: {
+    teamDashboardList: TeamDashboardList;
+    challengeList: ChallengeList;
+  };
+}
+export interface ReturnData {
+  data: {
+    teamDashboardList: TeamDashboardList;
+    challengeList: ChallengeList;
+  };
+}

--- a/src/types/TeamDashBoard.ts
+++ b/src/types/TeamDashBoard.ts
@@ -7,6 +7,7 @@ export interface TeamDashboardInfoResDto {
   description: string;
   blockProgress?: number;
   joinMembers?: string[] | null; // joinMembers가 배열일 수 있으므로 string[]로 정의. 타입에 따라 다를 수 있음.
+  invitedEmails?: string[];
 }
 // 전체 응답 구조를 정의
 export interface TeamDashboardResponse {


### PR DESCRIPTION
## 🪄 목적

> 관련 이슈 : #11 

<br />
<br />

## 💻 상세 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 팀 대시보드 생성 오류를 고치기 위해 경로를 수정했어요
- 마이페이지에서 팀 블록과 챌린지 블록을 얻어내기 위해 api 연동을 했어요

<br />
<br />

## 📸 스크린샷

<br />
<br />
<img width="557" alt="스크린샷 2024-09-12 오후 4 49 34" src="https://github.com/user-attachments/assets/c0261d7f-d4a7-45f4-a349-59f630735aad">

## 👼🏻 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
