### PR TITLE
#98 refactor: url 분리, usequery로 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,8 @@ import { useMediaQuery } from 'react-responsive';
 import Flex from './components/Flex';
 import { MobileDisplay } from './styles/ErrorPageStyled';
 import RouteChangeTracker from './components/RouteChangeTracker';
+import PersonalDashBoard from './components/PersonalDashboard';
+import TeamDashBoard from './components/TeamDashboard';
 
 const queryClient = new QueryClient();
 
@@ -93,7 +95,22 @@ const App = () => {
           <Route path="/api/oauth2/callback/:provider" element={<OAuthRedirectHandler />} />
           <Route path="/error/403" element={<Error403Page />} />
           <Route path="*" element={<Error404Page />} />
-
+          <Route
+            path="/personal/:id"
+            element={
+              <ProtectedRoute>
+                <PersonalDashBoard />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/team/:id"
+            element={
+              <ProtectedRoute>
+                <TeamDashBoard />
+              </ProtectedRoute>
+            }
+          />
           <Route
             path="/:id"
             element={

--- a/src/api/PersonalBlockApi.ts
+++ b/src/api/PersonalBlockApi.ts
@@ -26,7 +26,6 @@ export const patchPersonalBlock = async (
 ): Promise<number | null> => {
   try {
     const response = await axiosInstance.patch(`/blocks/${blockId}`, data);
-    console.log(response.data);
     return response.data;
   } catch (error) {
     console.error('Error fetching data:', error);
@@ -60,7 +59,6 @@ export const updatePersonalBlock = async (blockId?: string, progress?: string) =
 export const updateOrderBlock = async (data: BlockOrder) => {
   try {
     const response = await axiosInstance.patch(`/blocks/change`, data);
-    console.log(response);
     return response.data;
   } catch (error) {
     console.log('Error fetching data:', error);
@@ -72,7 +70,6 @@ export const getDeleteBlock = async (dashboardId: string, page?: number, size?: 
     const response = await axiosInstance.get(
       `/blocks/deleted?dashboardId=${dashboardId}&page=0&size=10`
     );
-    console.log(response);
     return response.data.data;
   } catch (error) {
     console.log('Error fetching data:', error);
@@ -82,8 +79,6 @@ export const getDeleteBlock = async (dashboardId: string, page?: number, size?: 
 export const deleteBlock = async (blockId: string) => {
   try {
     const response = await axiosInstance.delete(`/blocks/${blockId}`);
-
-    console.log(response);
   } catch (error) {
     console.error('Error fetching data:', error);
   }
@@ -92,7 +87,6 @@ export const deleteBlock = async (blockId: string) => {
 export const realDeleteBlock = async (blockId: string) => {
   try {
     const response = await axiosInstance.delete(`/blocks/permanent/${blockId}`);
-    console.log(response);
   } catch (error) {
     console.error('Error fetching data:', error);
   }
@@ -101,7 +95,6 @@ export const realDeleteBlock = async (blockId: string) => {
 export const restoreBlockFunc = async (blockId: string) => {
   try {
     const response = await axiosInstance.delete(`/blocks/${blockId}`);
-    console.log(response);
   } catch (error) {
     console.error('Error fetching data:', error);
   }

--- a/src/components/DashBoardLayout.tsx
+++ b/src/components/DashBoardLayout.tsx
@@ -1,0 +1,21 @@
+import { Helmet } from 'react-helmet-async';
+import Navbar from './Navbar';
+import Header from './Header';
+import * as S from '../styles/MainPageStyled';
+import { DeleteButton } from '@blocknote/react';
+import { DragDropContext } from 'react-beautiful-dnd';
+
+interface DashBoardLayoutProps {
+  children: React.ReactNode; // children의 타입을 명시합니다.
+}
+const DashBoardLayout = ({ children }: DashBoardLayoutProps) => {
+  return (
+    <>
+      <S.MainDashBoardLayout>
+        <Navbar />
+        <S.MainDashBoardContainer>{children}</S.MainDashBoardContainer>
+      </S.MainDashBoardLayout>
+    </>
+  );
+};
+export default DashBoardLayout;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -20,8 +20,14 @@ const Dashboard = ({ text, dashboard }: Props) => {
   const id = location.pathname.split('/')[1];
   const [groupedDashboard, setGroupedDashboard] = useState<GroupedDashboards>({});
 
-  const onClick = (id: number | string) => {
-    navigate(`/${id}`);
+  const onChangeLocation = (id: number | string) => {
+    if (text === '개인') {
+      navigate(`/personal/${id}`);
+      localStorage.setItem('PageSort', String('personal'));
+    } else {
+      navigate(`/team/${id}`);
+      localStorage.setItem('PageSort', String('team'));
+    }
     localStorage.setItem('LatestBoard', String(id));
   };
 
@@ -57,7 +63,7 @@ const Dashboard = ({ text, dashboard }: Props) => {
             <S.TeamDashboardItem
               key={index}
               onClick={() => {
-                onClick(value.dashboardId ?? 0);
+                onChangeLocation(value.dashboardId ?? 0);
               }}
             >
               {value.title}
@@ -73,7 +79,7 @@ const Dashboard = ({ text, dashboard }: Props) => {
               {groupedDashboard[category].map(dashboardItem => (
                 <S.PersonalDashboardItem
                   key={dashboardItem.dashboardId}
-                  onClick={() => onClick(dashboardItem.dashboardId ?? 0)}
+                  onClick={() => onChangeLocation(dashboardItem.dashboardId ?? 0)}
                 >
                   {dashboardItem.title}
                 </S.PersonalDashboardItem>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -23,10 +23,10 @@ const Dashboard = ({ text, dashboard }: Props) => {
   const onChangeLocation = (id: number | string) => {
     if (text === '개인') {
       navigate(`/personal/${id}`);
-      localStorage.setItem('PageSort', String('personal'));
+      localStorage.setItem('PageSort', 'personal');
     } else {
       navigate(`/team/${id}`);
-      localStorage.setItem('PageSort', String('team'));
+      localStorage.setItem('PageSort', 'team');
     }
     localStorage.setItem('LatestBoard', String(id));
   };

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -3,11 +3,11 @@ import deleteicon from '../img/delete2.png';
 import * as S from '../styles/MainPageStyled';
 import { Droppable } from 'react-beautiful-dnd';
 import Block from './Block';
-import { BlockListResDto } from '../types/PersonalBlock';
+import { BlockListResDto, DeletedBlockList } from '../types/PersonalBlock';
 
 interface Props {
   id: string;
-  list: BlockListResDto[];
+  list: DeletedBlockList;
   removeValue: boolean;
 }
 const DeleteButton = ({ id, list, removeValue }: Props) => {
@@ -30,7 +30,7 @@ const DeleteButton = ({ id, list, removeValue }: Props) => {
             <S.DeleteDiv ref={provided.innerRef} className="container" {...provided.droppableProps}>
               <h1>휴지통</h1>
               <S.BoxContainer>
-                {list.map(
+                {list.blockListResDto.map(
                   (
                     { title, blockId, contents, dDay, dashboardId, dType, nickname, picture },
                     index

--- a/src/components/PersonalDashboard.tsx
+++ b/src/components/PersonalDashboard.tsx
@@ -1,0 +1,84 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getPersonalBlock, getPersonalDashboard } from '../api/BoardApi';
+import { getDeleteBlock } from '../api/PersonalBlockApi';
+import DashBoardLayout from './DashBoardLayout';
+import Header from './Header';
+import { useLocation } from 'react-router-dom';
+import NotStartedDashboard from './NotStartedDashboard';
+import InProgressDashboard from './InProgressDashboard';
+import CompletedDashboard from './CompletedDashboard';
+import { useState } from 'react';
+import { DragDropContext } from 'react-beautiful-dnd';
+import * as S from '../styles/MainPageStyled';
+import DeleteButton from './DeleteButton';
+
+const PersonalDashBoard = () => {
+  const location = useLocation();
+
+  const dashboardId = location.pathname.split('/')[2];
+
+  const [page, setPage] = useState<number>(0);
+
+  const { data: NotStarted } = useQuery({
+    queryKey: ['NOT_STARTED', dashboardId],
+    queryFn: () => getPersonalBlock(dashboardId, 0, 10, 'NOT_STARTED'),
+  });
+  const { data: InProgress } = useQuery({
+    queryKey: ['IN_PROGRESS', dashboardId],
+    queryFn: () => getPersonalBlock(dashboardId, 0, 10, 'IN_PROGRESS'),
+  });
+  const { data: COMPLETED } = useQuery({
+    queryKey: ['COMPLETED', dashboardId],
+    queryFn: () => getPersonalBlock(dashboardId, 0, 10, 'COMPLETED'),
+  });
+  const { data: DeletedBlock } = useQuery({
+    queryKey: ['DeletedBlock', dashboardId],
+    queryFn: () => getDeleteBlock(dashboardId),
+  });
+  console.log('지운거 조회 :', DeletedBlock);
+  const { data: PersonalDashboardInfo } = useQuery({
+    queryKey: ['PersonalDashboardInfo', dashboardId],
+    queryFn: () => getPersonalDashboard(dashboardId),
+  });
+
+  // 세로 무한 스크롤 감지 이벤트
+  const handleLoadMore = async () => {
+    setPage(prevPage => prevPage + 1);
+  };
+  return (
+    <>
+      <DashBoardLayout>
+        <Header
+          mainTitle={PersonalDashboardInfo?.title || ''}
+          subTitle={PersonalDashboardInfo?.description || ''}
+          blockProgress={(Math.floor(PersonalDashboardInfo?.blockProgress ?? 0) * 10) / 10}
+          dashboardType={true}
+        />
+        <DragDropContext onDragEnd={() => {}}>
+          <S.CardContainer>
+            <NotStartedDashboard
+              list={NotStarted?.blockListResDto || []}
+              id="NOT_STARTED"
+              dashboardId={dashboardId}
+              onLoadMore={handleLoadMore}
+            ></NotStartedDashboard>
+            <InProgressDashboard
+              list={InProgress?.blockListResDto || []}
+              id="IN_PROGRESS"
+              dashboardId={dashboardId}
+              onLoadMore={handleLoadMore}
+            ></InProgressDashboard>
+            <CompletedDashboard
+              list={COMPLETED?.blockListResDto || []}
+              id="COMPLETED"
+              dashboardId={dashboardId}
+              onLoadMore={handleLoadMore}
+            ></CompletedDashboard>
+          </S.CardContainer>
+          <DeleteButton key="delete" id="delete" removeValue={true} list={DeletedBlock || []} />
+        </DragDropContext>
+      </DashBoardLayout>
+    </>
+  );
+};
+export default PersonalDashBoard;

--- a/src/components/TeamDashboard.tsx
+++ b/src/components/TeamDashboard.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getPersonalBlock } from '../api/BoardApi';
+import { getDeleteBlock } from '../api/PersonalBlockApi';
+import { getTeamDashboard } from '../api/TeamDashBoardApi';
+import DashBoardLayout from './DashBoardLayout';
+import Header from './Header';
+import { DragDropContext } from 'react-beautiful-dnd';
+import NotStartedDashboard from './NotStartedDashboard';
+import InProgressDashboard from './InProgressDashboard';
+import CompletedDashboard from './CompletedDashboard';
+import DeleteButton from './DeleteButton';
+import * as S from '../styles/MainPageStyled';
+
+const TeamDashBoard = () => {
+  const dashboardId = location.pathname.split('/')[2];
+
+  const [page, setPage] = useState<number>(0);
+
+  const { data: NotStarted } = useQuery({
+    queryKey: ['NOT_STARTED'],
+    queryFn: () => getPersonalBlock(dashboardId, 0, 10, 'NOT_STARTED'),
+  });
+
+  const { data: InProgress } = useQuery({
+    queryKey: ['IN_PROGRESS'],
+    queryFn: () => getPersonalBlock(dashboardId, 0, 10, 'IN_PROGRESS'),
+  });
+
+  const { data: COMPLETED } = useQuery({
+    queryKey: ['COMPLETED'],
+    queryFn: () => getPersonalBlock(dashboardId, 0, 10, 'COMPLETED'),
+  });
+
+  const { data: DeletedBlock } = useQuery({
+    queryKey: ['DeletedBlock'],
+    queryFn: () => getDeleteBlock(dashboardId),
+  });
+  const { data: TeamDashboardInfo } = useQuery({
+    queryKey: ['TeamDashboardInfo'],
+    queryFn: () => getTeamDashboard(dashboardId),
+  });
+  // 세로 무한 스크롤 감지 이벤트
+  const handleLoadMore = async () => {
+    setPage(prevPage => prevPage + 1);
+  };
+  return (
+    <>
+      <DashBoardLayout>
+        <Header
+          mainTitle={TeamDashboardInfo?.title || ''}
+          subTitle={TeamDashboardInfo?.description || ''}
+          blockProgress={(Math.floor(TeamDashboardInfo?.blockProgress ?? 0) * 10) / 10}
+        />
+        <DragDropContext onDragEnd={() => {}}>
+          <S.CardContainer>
+            <NotStartedDashboard
+              list={NotStarted?.blockListResDto || []}
+              id="NOT_STARTED"
+              dashboardId={dashboardId}
+              onLoadMore={handleLoadMore}
+            ></NotStartedDashboard>
+            <InProgressDashboard
+              list={InProgress?.blockListResDto || []}
+              id="IN_PROGRESS"
+              dashboardId={dashboardId}
+              onLoadMore={handleLoadMore}
+            ></InProgressDashboard>
+            <CompletedDashboard
+              list={COMPLETED?.blockListResDto || []}
+              id="COMPLETED"
+              dashboardId={dashboardId}
+              onLoadMore={handleLoadMore}
+            ></CompletedDashboard>
+          </S.CardContainer>
+          <DeleteButton key="delete" id="delete" removeValue={true} list={DeletedBlock || []} />
+        </DragDropContext>
+      </DashBoardLayout>
+    </>
+  );
+};
+export default TeamDashBoard;

--- a/src/contexts/OAuthRedirectHandler.tsx
+++ b/src/contexts/OAuthRedirectHandler.tsx
@@ -33,7 +33,8 @@ const OAuthRedirectHandler = () => {
 
       // * 마지막에 방문한 대시보드가 있다면 해당 대시보드로 이동, 없다면 튜토리얼 페이지로 이동
       const latestBoard = localStorage.getItem('LatestBoard');
-      navigate(latestBoard ? `/${latestBoard}` : '/tutorial');
+      const dashboardSort = localStorage.getItem('PageSort');
+      navigate(latestBoard ? `/${dashboardSort}/${latestBoard}` : '/tutorial');
     }
   }, [loginToken, login, navigate]);
 

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -42,7 +42,6 @@ export const useSSE = () => {
 
     // 메시지 수신 처리
     eventSource.current.onmessage = event => {
-      console.log(event.data);
       if (!event.data.includes('연결')) {
         const modifiedMessage = event.data.replace(/^[^:]+: /, '').replace(/\d+$/, '');
         customErrToast(modifiedMessage);

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -360,7 +360,7 @@ const MainPage = () => {
                 );
               })}
             </S.CardContainer>
-            <DeleteButton key="delete" id="delete" removeValue={true} list={columns.delete.list} />
+            {/* <DeleteButton key="delete" id="delete" removeValue={true} list={columns.delete.list} /> */}
           </DragDropContext>
         </S.MainDashBoardContainer>
       </S.MainDashBoardLayout>

--- a/src/types/PersonalBlock.ts
+++ b/src/types/PersonalBlock.ts
@@ -19,6 +19,10 @@ export interface BlockListResDto {
   picture?: string;
 }
 
+export interface DeletedBlockList {
+  blockListResDto: BlockListResDto[];
+  pageInfoResDto: PageInfoResDto;
+}
 export interface PageInfoResDto {
   currentPage: number;
   totalPages: number;


### PR DESCRIPTION
## 🪄 목적

> 관련 이슈 : #98 

<br />
<br />

## 💻 상세 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- navbar에서 대시보드를 눌렀을때 팀과 개인을 나누어서 주소를 이동하도록 하게 했어요
- useQuery를 통해 데이터를 받아오도록 변경했어요
- 일단 dragend함수가 실행되지는 않아요
- 그리고 헤더의 팀문서 버튼을 눌렀을시 다른 링크로 가도록 해야해요

<br />
<br />

## 📸 스크린샷

<br />
<br />

![스크린샷 2024-10-26 오후 3 52 04](https://github.com/user-attachments/assets/f0db166f-5eda-4df0-a191-1b2468fede11)


## 👼🏻 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 작성해주세요.
