### PR TITLE
Block, Tag, DashbaordColumn UI 컴포넌트 구현

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -112,6 +112,9 @@ export default defineConfig(
       // ✅ 미사용 import 제거
       'unused-imports/no-unused-imports': 'warn',
       'unused-imports/no-unused-vars': 'off',
+
+      // emotion
+      'react/no-unknown-property': ['error', { ignore: ['css'] }],
     },
   },
 

--- a/src/components/Block_new/Block.style.ts
+++ b/src/components/Block_new/Block.style.ts
@@ -1,0 +1,43 @@
+import { css } from '@emotion/react';
+
+export const containerStyle = css({
+  padding: '0 1rem',
+  border: '1px solid #eee',
+  backgroundColor: '#fff',
+  borderRadius: '0.75rem',
+  maxWidth: '20rem',
+});
+
+export const headerStyle = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '0.625rem 0',
+  borderBottom: '1px dashed #eee',
+});
+
+export const contentStyle = css({
+  padding: '0.75rem 0',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.375rem',
+});
+
+export const titleStyle = css({
+  fontSize: '1rem',
+  fontWeight: 'bold',
+  color: '#2A2C30',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+});
+
+export const descriptionStyle = css({
+  fontSize: '0.875rem',
+  color: '#858585',
+  textOverflow: 'ellipsis',
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 2,
+  overflow: 'hidden',
+  lineHeight: '1.125rem',
+});

--- a/src/components/Block_new/Block.style.ts
+++ b/src/components/Block_new/Block.style.ts
@@ -2,8 +2,8 @@ import { css } from '@emotion/react';
 
 export const containerStyle = css({
   padding: '0 1rem',
-  border: '1px solid #eee',
-  backgroundColor: '#fff',
+  border: '1px solid var(--stroke2)',
+  backgroundColor: 'var(--white)',
   borderRadius: '0.75rem',
   maxWidth: '20rem',
 });
@@ -12,7 +12,7 @@ export const headerStyle = css({
   display: 'flex',
   justifyContent: 'space-between',
   padding: '0.625rem 0',
-  borderBottom: '1px dashed #eee',
+  borderBottom: '1px dashed var(--stroke2)',
 });
 
 export const contentStyle = css({
@@ -25,7 +25,7 @@ export const contentStyle = css({
 export const titleStyle = css({
   fontSize: '1rem',
   fontWeight: 'bold',
-  color: '#2A2C30',
+  color: 'var(--text)',
   textOverflow: 'ellipsis',
   overflow: 'hidden',
   whiteSpace: 'nowrap',
@@ -33,7 +33,7 @@ export const titleStyle = css({
 
 export const descriptionStyle = css({
   fontSize: '0.875rem',
-  color: '#858585',
+  color: 'var(--gray)',
   textOverflow: 'ellipsis',
   display: '-webkit-box',
   WebkitBoxOrient: 'vertical',

--- a/src/components/Block_new/Block.tsx
+++ b/src/components/Block_new/Block.tsx
@@ -1,0 +1,32 @@
+import Tag from '@/components/Tag_new/Tag';
+
+import { containerStyle, contentStyle, descriptionStyle, headerStyle, titleStyle } from './Block.style';
+
+const TAG_LABELS = {
+  todo: '시작 전',
+  inProgress: '진행 중',
+  done: '완료',
+  challenge: '도전! 챌린지',
+} as const;
+
+interface BlockProps {
+  tagVariant: 'todo' | 'inProgress' | 'done' | 'challenge';
+  dDay?: string;
+  title?: string;
+  description?: string;
+}
+
+export default function Block({ tagVariant, dDay, title, description }: BlockProps) {
+  return (
+    <div css={containerStyle}>
+      <div css={headerStyle}>
+        <Tag label={TAG_LABELS[tagVariant]} variant={tagVariant} />
+        <Tag label={dDay} variant='dDay' />
+      </div>
+      <div css={contentStyle}>
+        <p css={titleStyle}>{title}</p>
+        <div css={descriptionStyle}>{description}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DashboardColumn_new/DashboardColumn.style.ts
+++ b/src/components/DashboardColumn_new/DashboardColumn.style.ts
@@ -3,15 +3,15 @@ import { css } from '@emotion/react';
 export const COLUMN_CONFIG = {
   todo: {
     title: '시작 전',
-    dotColor: 'var(--main)',
+    dotColor: 'var(--main3)',
   },
   inProgress: {
     title: '진행 중',
-    dotColor: 'var(--main2)',
+    dotColor: 'var(--main)',
   },
   done: {
     title: '완료',
-    dotColor: 'var(--main3)',
+    dotColor: 'var(--main2)',
   },
 };
 

--- a/src/components/DashboardColumn_new/DashboardColumn.style.ts
+++ b/src/components/DashboardColumn_new/DashboardColumn.style.ts
@@ -3,15 +3,15 @@ import { css } from '@emotion/react';
 export const COLUMN_CONFIG = {
   todo: {
     title: '시작 전',
-    dotColor: '#00D1FF',
+    dotColor: 'var(--main)',
   },
   inProgress: {
     title: '진행 중',
-    dotColor: '#4C8CFF',
+    dotColor: 'var(--main2)',
   },
   done: {
     title: '완료',
-    dotColor: '#9847FF',
+    dotColor: 'var(--main3)',
   },
 };
 
@@ -23,7 +23,7 @@ export const containerStyle = css({
   gap: '1.25rem',
   padding: '1.25rem',
   backgroundColor: '#FAFAFA',
-  border: '1px solid #eee',
+  border: '1px solid var(--stroke2)',
   borderRadius: '1rem',
 });
 
@@ -47,7 +47,7 @@ export const baseDotStyle = css({
 export const titleStyle = css({
   fontSize: '0.875rem',
   fontWeight: 'bold',
-  color: '#858585',
+  color: 'var(--gray)',
 });
 
 export const blocksStyle = css({

--- a/src/components/DashboardColumn_new/DashboardColumn.style.ts
+++ b/src/components/DashboardColumn_new/DashboardColumn.style.ts
@@ -49,3 +49,9 @@ export const titleStyle = css({
   fontWeight: 'bold',
   color: '#858585',
 });
+
+export const blocksStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+});

--- a/src/components/DashboardColumn_new/DashboardColumn.style.ts
+++ b/src/components/DashboardColumn_new/DashboardColumn.style.ts
@@ -1,0 +1,51 @@
+import { css } from '@emotion/react';
+
+export const COLUMN_CONFIG = {
+  todo: {
+    title: '시작 전',
+    dotColor: '#00D1FF',
+  },
+  inProgress: {
+    title: '진행 중',
+    dotColor: '#4C8CFF',
+  },
+  done: {
+    title: '완료',
+    dotColor: '#9847FF',
+  },
+};
+
+export const containerStyle = css({
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.25rem',
+  padding: '1.25rem',
+  backgroundColor: '#FAFAFA',
+  border: '1px solid #eee',
+  borderRadius: '1rem',
+});
+
+export const headerStyle = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+});
+
+export const columnTitleStyle = css({
+  display: 'flex',
+  gap: '0.375rem',
+  alignItems: 'center',
+});
+
+export const baseDotStyle = css({
+  width: '0.75rem',
+  height: '0.75rem',
+  borderRadius: '100%',
+});
+
+export const titleStyle = css({
+  fontSize: '0.875rem',
+  fontWeight: 'bold',
+  color: '#858585',
+});

--- a/src/components/DashboardColumn_new/DashboardColumn.tsx
+++ b/src/components/DashboardColumn_new/DashboardColumn.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react';
 
+import Block from '../Block_new/Block';
 import {
   baseDotStyle,
+  blocksStyle,
   COLUMN_CONFIG,
   columnTitleStyle,
   containerStyle,
@@ -9,11 +11,20 @@ import {
   titleStyle,
 } from './DashboardColumn.style';
 
-interface DashboardColumnProps {
-  variant: 'todo' | 'inProgress' | 'done';
+interface BlockData {
+  id: string;
+  tagVariant: 'todo' | 'inProgress' | 'done' | 'challenge';
+  dDay?: string;
+  title?: string;
+  description?: string;
 }
 
-export default function DashboardColumn({ variant = 'todo' }: DashboardColumnProps) {
+interface DashboardColumnProps {
+  variant: 'todo' | 'inProgress' | 'done';
+  blocks?: BlockData[];
+}
+
+export default function DashboardColumn({ variant = 'todo', blocks }: DashboardColumnProps) {
   const config = COLUMN_CONFIG[variant];
 
   return (
@@ -28,7 +39,17 @@ export default function DashboardColumn({ variant = 'todo' }: DashboardColumnPro
         <div>+</div>
       </div>
 
-      <div>{/* Block 들어갈 div */}</div>
+      <div css={blocksStyle}>
+        {blocks?.map((block) => (
+          <Block
+            key={block.id}
+            dDay={block.dDay}
+            description={block.description}
+            tagVariant={block.tagVariant}
+            title={block.title}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/DashboardColumn_new/DashboardColumn.tsx
+++ b/src/components/DashboardColumn_new/DashboardColumn.tsx
@@ -1,0 +1,34 @@
+import { css } from '@emotion/react';
+
+import {
+  baseDotStyle,
+  COLUMN_CONFIG,
+  columnTitleStyle,
+  containerStyle,
+  headerStyle,
+  titleStyle,
+} from './DashboardColumn.style';
+
+interface DashboardColumnProps {
+  variant: 'todo' | 'inProgress' | 'done';
+}
+
+export default function DashboardColumn({ variant = 'todo' }: DashboardColumnProps) {
+  const config = COLUMN_CONFIG[variant];
+
+  return (
+    <div css={containerStyle}>
+      <div css={headerStyle}>
+        <div css={columnTitleStyle}>
+          <div css={[baseDotStyle, css({ backgroundColor: config.dotColor })]} />
+          <p css={titleStyle}>{config.title}</p>
+        </div>
+
+        {/* todo: Button 컴포넌트로 변경 */}
+        <div>+</div>
+      </div>
+
+      <div>{/* Block 들어갈 div */}</div>
+    </div>
+  );
+}

--- a/src/components/Tag_new/Tag.style.ts
+++ b/src/components/Tag_new/Tag.style.ts
@@ -11,39 +11,39 @@ export const sizeStyles = {
 };
 
 export const variantStyles = {
-  default: css({ backgroundColor: '#fff', color: '#858585', border: '1px solid #eee' }),
+  default: css({ backgroundColor: 'var(--white)', color: 'var(--gray)', border: '1px solid var(--stroke2)' }),
   todo: css({
     backgroundColor: '#E5FAFF',
-    color: '#00D1FF',
+    color: 'var(--main3)',
     border: '1px solid #E5FAFF',
   }),
   inProgress: css({
     backgroundColor: '#EDF3FF',
-    color: '#4C8CFF',
+    color: 'var(--main)',
     border: '1px solid #EDF3FF',
   }),
   done: css({
     backgroundColor: '#F5EDFF',
-    color: '#9847FF',
+    color: 'var(--main2)',
     border: '1px solid #F5EDFF',
   }),
   challenge: css({
-    backgroundColor: '#fff',
-    background: 'linear-gradient(90deg, #4C8CFF 0%, #9847FF 100%)',
+    backgroundColor: 'var(--white)',
+    background: 'linear-gradient(90deg, var(--main) 0%, var(--main2) 100%)',
     WebkitBackgroundClip: 'text',
     WebkitTextFillColor: 'transparent',
     backgroundClip: 'text',
-    border: '1px solid #eee',
+    border: '1px solid var(--stroke2)',
   }),
   dDay: css({
     backgroundColor: '#F3F3F3',
-    color: '#858585',
+    color: 'var(--gray)',
     fontWeight: 'bold',
     border: '1px solid #F3F3F3',
   }),
   urgent: css({
     backgroundColor: '#FFEBEB',
-    color: '#FF383C',
+    color: 'var(--red)',
     fontWeight: 'bold',
     border: '1px solid #FFEBEB',
   }),

--- a/src/components/Tag_new/Tag.style.ts
+++ b/src/components/Tag_new/Tag.style.ts
@@ -1,0 +1,50 @@
+import { css } from '@emotion/react';
+
+export const baseTagStyle = css({
+  width: 'fit-content',
+  borderRadius: '1.5rem',
+});
+
+export const sizeStyles = {
+  md: css({ padding: '0.125rem 0.375rem', fontSize: '0.875rem' }),
+  lg: css({ padding: '0.375rem 0.75rem', fontSize: '1rem' }),
+};
+
+export const variantStyles = {
+  default: css({ backgroundColor: '#fff', color: '#858585', border: '1px solid #eee' }),
+  todo: css({
+    backgroundColor: '#E5FAFF',
+    color: '#00D1FF',
+    border: '1px solid #E5FAFF',
+  }),
+  inProgress: css({
+    backgroundColor: '#EDF3FF',
+    color: '#4C8CFF',
+    border: '1px solid #EDF3FF',
+  }),
+  done: css({
+    backgroundColor: '#F5EDFF',
+    color: '#9847FF',
+    border: '1px solid #F5EDFF',
+  }),
+  challenge: css({
+    backgroundColor: '#fff',
+    background: 'linear-gradient(90deg, #4C8CFF 0%, #9847FF 100%)',
+    WebkitBackgroundClip: 'text',
+    WebkitTextFillColor: 'transparent',
+    backgroundClip: 'text',
+    border: '1px solid #eee',
+  }),
+  dDay: css({
+    backgroundColor: '#F3F3F3',
+    color: '#858585',
+    fontWeight: 'bold',
+    border: '1px solid #F3F3F3',
+  }),
+  urgent: css({
+    backgroundColor: '#FFEBEB',
+    color: '#FF383C',
+    fontWeight: 'bold',
+    border: '1px solid #FFEBEB',
+  }),
+};

--- a/src/components/Tag_new/Tag.tsx
+++ b/src/components/Tag_new/Tag.tsx
@@ -1,0 +1,11 @@
+import { baseTagStyle, sizeStyles, variantStyles } from './Tag.style';
+
+interface TagProps {
+  label?: string;
+  variant?: 'default' | 'todo' | 'inProgress' | 'done' | 'challenge' | 'dDay' | 'urgent';
+  size?: 'md' | 'lg';
+}
+
+export default function Tag({ label, variant = 'todo', size = 'md' }: TagProps) {
+  return <p css={[baseTagStyle, variantStyles[variant], sizeStyles[size]]}>{label}</p>;
+}

--- a/src/styles/GlobalStyle/Global.styles.tsx
+++ b/src/styles/GlobalStyle/Global.styles.tsx
@@ -11,6 +11,7 @@ const resetStyle = css`
   :root {
     --black: #101010;
     --white: #fdfdfd;
+    --red: #ff383c;
     --main: #4c8cff;
     --main2: #9847ff;
     --main3: #00d1ff;
@@ -20,7 +21,7 @@ const resetStyle = css`
     --navbar: #f5f5f5;
     --gradation: linear-gradient(90deg, #4c8cff 0%, #9847ff 100%);
     --border: #b0b0b0;
-    --stroke2: #f4f4f4;
+    --stroke2: #eeeeee;
     --toastify-color-progress-light: linear-gradient(to right, #4c8cff, #9847ff, #00d1ff);
   }
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "jsxImportSource": "@emotion/react",
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,12 @@ import { defineConfig, type PluginOption } from 'vite';
 
 export default defineConfig(() => {
   return {
-    plugins: [react(), visualizer() as PluginOption],
+    plugins: [
+      react({
+        jsxImportSource: '@emotion/react',
+      }),
+      visualizer() as PluginOption,
+    ],
     resolve: {
       alias: {
         '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #145

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- **emotion 추가 설정**
  1. `tsconfig.app.json`에 emotion 등록
  2. `eslint.config.mjs`에 css prop 허용
  3. `vite.config.ts`에 `jsxImportSource`로 emotion 등록
- **Block, Tag, DashbaordColumn UI 컴포넌트 구현**
  - `DashbaordColumn`은 시작 전/진행 중/완료의 상태별 컬럼이고, `Block` 컴포넌트를 렌더링합니다.
  - `DashboardColumn`은 드래그앤드롭으로 `Block` 데이터를 관리해야 하기 때문에, `Block` 데이터를 객체 리스트로 전달받는 구조로 설계했습니다. (children으로 Block 컴포넌트 자체를 받는 방식과 고민했습니다.)
  - `DashbaordColumn`의 `+` 버튼은 나중에 공통 `Button` 컴포넌트로 변경할 예정입니다.
  - `Block` 컴포넌트는 제목은 1줄, 내용은 2줄까지 보여지며, 분량을 넘기는 경우 말줄임(...) 표시됩니다.
  - `Tag`는 `default` / `todo` / `inProgress` / `done` / `challenge` / `dDay` / `urgent`의 타입을 제공합니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

<img width="974" height="893" alt="image" src="https://github.com/user-attachments/assets/fd0a2ba0-6870-41cc-ab46-31175215120e" />


## ❓무슨 문제가 발생했나요? (선택)

-

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
